### PR TITLE
Use java file with specified path insted of used cd command in lyv.sh

### DIFF
--- a/src/main/assembly/resources/lyv.sh
+++ b/src/main/assembly/resources/lyv.sh
@@ -23,4 +23,4 @@ APP_NAME=`echo "${JAR_FILE}" | sed -e 's/^\(.*\)-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(
 APP_VERSION=`echo "${JAR_FILE}" | sed -e 's/^.*-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(-SNAPSHOT\)\?\(-javadoc\)\?\.jar$/\1\2/'`
 
 # Run the application
-( cd "${SCRIPT_DIR}" && ${JAVA_HOME}/bin/java -jar "${APP_NAME}-${APP_VERSION}.jar" $* )
+(${JAVA_HOME}/bin/java -jar "${SCRIPT_DIR}"/"${APP_NAME}-${APP_VERSION}.jar" $* )


### PR DESCRIPTION
Using cd before executing jar file prevent to use lyv.sh as a alias.
Executing jar file with specified path in this case enabled option
used lyv.sh like:
lyv -f tree ./model.yang
Without this changes will be required to use full path for yang model.

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>