### PR TITLE
Fix Major SonarCloud code smell issues

### DIFF
--- a/src/main/java/io/lighty/yang/validator/CompilationStatus.java
+++ b/src/main/java/io/lighty/yang/validator/CompilationStatus.java
@@ -18,6 +18,7 @@ public enum CompilationStatus {
         this.name = name;
     }
 
+    @Override
     public String toString() {
         return this.name;
     }

--- a/src/main/java/io/lighty/yang/validator/Main.java
+++ b/src/main/java/io/lighty/yang/validator/Main.java
@@ -190,7 +190,7 @@ public final class Main {
         table.buildHtml();
     }
 
-    private static String getYangtoolsVersion(Class clazz) {
+    private static String getYangtoolsVersion(Class<?> clazz) {
         String className = clazz.getSimpleName() + ".class";
         String classPath = clazz.getResource(className).toString();
         if (!classPath.startsWith("jar")) {
@@ -328,7 +328,7 @@ public final class Main {
                     try (FileInputStream fis = new FileInputStream(xmlFile)) {
                         schemaSelector.addXml(fis);
                     } catch (IOException | XMLStreamException | URISyntaxException e) {
-                        LOG.error("Failed to fill schema from {}", xmlFile.toString(), e);
+                        LOG.error("Failed to fill schema from {}", xmlFile, e);
                         throw new RuntimeException(e);
                     }
                 }

--- a/src/main/java/io/lighty/yang/validator/YangContextFactory.java
+++ b/src/main/java/io/lighty/yang/validator/YangContextFactory.java
@@ -163,7 +163,7 @@ final class YangContextFactory {
         final List<File> yangFiles = new ArrayList<>();
         File[] files = dir.listFiles();
         if (files == null) {
-            return null;
+            return Collections.EMPTY_LIST;
         }
         for (final File file : files) {
             if (file.isDirectory()) {

--- a/src/main/java/io/lighty/yang/validator/YangContextFactory.java
+++ b/src/main/java/io/lighty/yang/validator/YangContextFactory.java
@@ -153,7 +153,7 @@ final class YangContextFactory {
         } else {
             File[] files = testSourcesDir.listFiles(YANG_FILE_FILTER);
             if (files == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             return Arrays.asList(files);
         }
@@ -163,7 +163,7 @@ final class YangContextFactory {
         final List<File> yangFiles = new ArrayList<>();
         File[] files = dir.listFiles();
         if (files == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         for (final File file : files) {
             if (file.isDirectory()) {

--- a/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFromErrorRFC6020.java
+++ b/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFromErrorRFC6020.java
@@ -11,7 +11,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings({"SLF4J_FORMAT_SHOULD_BE_CONST", "SLF4J_SIGN_ONLY_FORMAT"})
 class CheckUpdateFromErrorRFC6020 {
 
     private static final String PRETEXT = "According to RFC 6020 ";
@@ -160,6 +159,8 @@ class CheckUpdateFromErrorRFC6020 {
         return this;
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     void print(int order) {
         LOG.error("{} {}: {}{}{}{}\n", order, name, PRETEXT, description, newInformation, oldInformation);
     }

--- a/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
@@ -42,12 +42,12 @@ public class Analyzer extends FormatPlugin {
         }
     }
 
-    private void analyzeSubstatement(final DeclaredStatement subStatement) {
+    private void analyzeSubstatement(final DeclaredStatement<?> subStatement) {
         String name = subStatement.statementDefinition().getStatementName().getLocalName();
         counter.compute(name, (key, val) -> (val == null) ? 1 : val + 1);
-        final Collection substatements = subStatement.declaredSubstatements();
+        final Collection<?> substatements = subStatement.declaredSubstatements();
         for (final Object nextSubstatement : substatements) {
-            analyzeSubstatement((DeclaredStatement)nextSubstatement);
+            analyzeSubstatement((DeclaredStatement<?>)nextSubstatement);
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
@@ -19,7 +19,6 @@ import org.opendaylight.yangtools.yang.parser.stmt.reactor.EffectiveSchemaContex
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("SLF4J_FORMAT_SHOULD_BE_CONST")
 public class Analyzer extends FormatPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(Analyzer.class);
@@ -36,18 +35,20 @@ public class Analyzer extends FormatPlugin {
         printOut();
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     private void printOut() {
         for (Map.Entry<String, Integer> entry : new TreeMap<>(this.counter).entrySet()) {
-            LOG.info(String.format("%s: %d", entry.getKey(), entry.getValue()));
+            LOG.info("{}: {}", entry.getKey(), entry.getValue());
         }
     }
 
     private void analyzeSubstatement(final DeclaredStatement<?> subStatement) {
         String name = subStatement.statementDefinition().getStatementName().getLocalName();
         counter.compute(name, (key, val) -> (val == null) ? 1 : val + 1);
-        final Collection<?> substatements = subStatement.declaredSubstatements();
-        for (final Object nextSubstatement : substatements) {
-            analyzeSubstatement((DeclaredStatement<?>)nextSubstatement);
+        final Collection<? extends DeclaredStatement<?>> substatements = subStatement.declaredSubstatements();
+        for (final DeclaredStatement<?> nextSubstatement : substatements) {
+            analyzeSubstatement(nextSubstatement);
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/Depends.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Depends.java
@@ -24,7 +24,7 @@ import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("SLF4J_FORMAT_SHOULD_BE_CONST")
+
 public class Depends extends FormatPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(Depends.class);
@@ -41,6 +41,8 @@ public class Depends extends FormatPlugin {
     private final Set<String> modules = new HashSet<>();
 
     @Override
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
         final DependConfiguration dependConfiguration = this.configuration.getDependConfiguration();
         for (final RevisionSourceIdentifier source : this.sources) {
@@ -71,7 +73,7 @@ public class Depends extends FormatPlugin {
                 dependantsBuilder.append(NON_RECURSIVE);
             }
             final String dependandsText = dependantsBuilder.toString();
-            LOG.info(dependandsText);
+            LOG.info("{}", dependandsText);
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -43,7 +43,6 @@ import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
 public class JsTree extends FormatPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(JsTree.class);
@@ -54,6 +53,8 @@ public class JsTree extends FormatPlugin {
     private final Map<URI, String> namespacePrefix = new HashMap<>();
 
     @Override
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
         for (final RevisionSourceIdentifier source : this.sources) {
             final Module module = this.schemaContext.findModule(source.getName(), source.getRevision())
@@ -84,6 +85,8 @@ public class JsTree extends FormatPlugin {
         LOG.info("</html>");
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     private void printLines(final List<Line> lines) {
         for (Line line : lines) {
             LOG.info("{}", line.toString());
@@ -140,6 +143,8 @@ public class JsTree extends FormatPlugin {
         return lines;
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     private List<Line> getChildNodesLines(final SingletonListInitializer singletonListInitializer,
             final Module module, final List<Integer> removeChoiceQnames) {
         List<Line> lines = new ArrayList<>();

--- a/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
@@ -53,7 +53,6 @@ import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("SLF4J_FORMAT_SHOULD_BE_CONST")
 public class JsonTree extends FormatPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(JsonTree.class);
@@ -114,6 +113,8 @@ public class JsonTree extends FormatPlugin {
     }
 
     @Override
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
         for (final RevisionSourceIdentifier source : this.sources) {
             final Module module = this.schemaContext.findModule(source.getName(), source.getRevision())
@@ -150,7 +151,7 @@ public class JsonTree extends FormatPlugin {
             }
             jsonTree.put(MODULE, moduleMetadata);
             final String jsonTreeText = jsonTree.toString(4);
-            LOG.info(jsonTreeText);
+            LOG.info("{}", jsonTreeText);
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/Line.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Line.java
@@ -41,7 +41,6 @@ import org.opendaylight.yangtools.yang.model.api.type.IdentityrefTypeDefinition;
 import org.opendaylight.yangtools.yang.model.api.type.LeafrefTypeDefinition;
 import org.opendaylight.yangtools.yang.model.util.BaseTypes;
 import org.opendaylight.yangtools.yang.parser.rfc7950.stmt.AbstractDeclaredEffectiveStatement;
-import org.opendaylight.yangtools.yang.parser.rfc7950.stmt.DeclaredEffectiveStatementBase;
 
 abstract class Line {
 
@@ -119,17 +118,16 @@ abstract class Line {
     }
 
     private void resolveIfFeatures(SchemaNode node) {
-        final DeclaredStatement declared = getDeclared(node);
+        final DeclaredStatement<?> declared = getDeclared(node);
         if (declared instanceof IfFeatureAwareDeclaredStatement) {
-            final Collection ifFeature = ((IfFeatureAwareDeclaredStatement) declared).getIfFeatures();
+            final Collection<IfFeatureStatement> ifFeature
+                    = ((IfFeatureAwareDeclaredStatement) declared).getIfFeatures();
             this.ifFeatures.addAll(ifFeature);
         }
     }
 
-    private DeclaredStatement getDeclared(final SchemaNode node) {
-        if (node instanceof DeclaredEffectiveStatementBase) {
-            return ((DeclaredEffectiveStatementBase) node).getDeclared();
-        } else if (node instanceof AbstractDeclaredEffectiveStatement) {
+    private DeclaredStatement<?> getDeclared(final SchemaNode node) {
+        if (node instanceof AbstractDeclaredEffectiveStatement) {
             return ((AbstractDeclaredEffectiveStatement) node).getDeclared();
         }
         return null;

--- a/src/main/java/io/lighty/yang/validator/formats/MultiModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/MultiModulePrinter.java
@@ -44,7 +44,7 @@ public class MultiModulePrinter extends FormatPlugin {
     private static final String HELP_NAME = "yang";
     private static final String HELP_DESCRIPTION = "print raw yang module according to RFC7950";
 
-    private final Map<QNameModule, Set<TypeDefinition>> usedImportedTypeDefs = new HashMap<>();
+    private final Map<QNameModule, Set<TypeDefinition<?>>> usedImportedTypeDefs = new HashMap<>();
     private final Map<QNameModule, Set<String>> usedImports = new HashMap<>();
     private final Map<QNameModule, Set<SchemaTree>> subtrees = new HashMap<>();
 
@@ -121,8 +121,8 @@ public class MultiModulePrinter extends FormatPlugin {
         }
     }
 
-    private static TypeDefinition getRootType(final TypeDefinition typeDefinition) {
-        TypeDefinition typeDef = typeDefinition;
+    private static TypeDefinition<?> getRootType(final TypeDefinition<?> typeDefinition) {
+        TypeDefinition<?> typeDef = typeDefinition;
         while (typeDef.getBaseType() != null) {
             typeDef = typeDef.getBaseType();
         }
@@ -142,7 +142,7 @@ public class MultiModulePrinter extends FormatPlugin {
     }
 
     private void resolveType(final TypeDefinition<? extends TypeDefinition<?>> type, final Module module) {
-        final TypeDefinition rootType = getRootType(type);
+        final TypeDefinition<?> rootType = getRootType(type);
         final String rootLocalName = rootType.getQName().getLocalName();
         if (!Objects.equals(rootLocalName, type.getQName().getLocalName()) && !rootLocalName.equals("boolean")) {
             final QNameModule mod = QNameModule.create(type.getQName().getNamespace(), type.getQName().getRevision());

--- a/src/main/java/io/lighty/yang/validator/formats/NameRevision.java
+++ b/src/main/java/io/lighty/yang/validator/formats/NameRevision.java
@@ -17,7 +17,7 @@ import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("SLF4J_FORMAT_SHOULD_BE_CONST")
+
 public class NameRevision extends FormatPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(NameRevision.class);
@@ -26,6 +26,8 @@ public class NameRevision extends FormatPlugin {
     private static final String ET = "@";
 
     @Override
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
         for (final RevisionSourceIdentifier source : this.sources) {
             final Module module = this.schemaContext.findModule(source.getName(), source.getRevision())
@@ -35,7 +37,7 @@ public class NameRevision extends FormatPlugin {
             if (revision.isPresent()) {
                 moduleName += ET + revision.get().toString();
             }
-            LOG.info(moduleName);
+            LOG.info("{}", moduleName);
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/Tree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Tree.java
@@ -47,7 +47,6 @@ import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@SuppressFBWarnings("SLF4J_SIGN_ONLY_FORMAT")
 public class Tree extends FormatPlugin {
 
     private static final Logger LOG = LoggerFactory.getLogger(Tree.class);
@@ -75,6 +74,8 @@ public class Tree extends FormatPlugin {
     }
 
     @Override
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
         if (this.configuration.getTreeConfiguration().isHelp()) {
             printHelp();
@@ -483,6 +484,8 @@ public class Tree extends FormatPlugin {
         }
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     private void printLines(final List<Line> lines) {
         for (Line l : lines) {
             final String linesText = l.toString();

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/Indenting.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/Indenting.java
@@ -25,10 +25,8 @@ abstract class Indenting {
         for (int i = 0; i < level; i++) {
             builder.append("    ");
         }
-        if (!separately) {
-            if (!name.isEmpty()) {
+        if (!separately && (!name.isEmpty())) {
                 name += " ";
-            }
         }
         builder.append(name);
         if (separately) {

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/Indenting.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/Indenting.java
@@ -26,7 +26,7 @@ abstract class Indenting {
             builder.append("    ");
         }
         if (!separately && (!name.isEmpty())) {
-                name += " ";
+            name += " ";
         }
         builder.append(name);
         if (separately) {

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/IndentingLogger.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/IndentingLogger.java
@@ -10,7 +10,6 @@ package io.lighty.yang.validator.formats.yang.printer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 
-@SuppressFBWarnings("SLF4J_FORMAT_SHOULD_BE_CONST")
 class IndentingLogger extends Indenting {
 
     private final Logger log;
@@ -19,19 +18,24 @@ class IndentingLogger extends Indenting {
         this.log = log;
     }
 
-
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     void println(int level, final String name, final String text, final boolean separately) {
         final String indent = indent(level, name, text, separately);
-        this.log.info(indent);
+        this.log.info("{}", indent);
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     void println(final int level, final String text) {
         final String indent = indent(level, "", text, false);
-        this.log.info(indent);
+        this.log.info("{}", indent);
     }
 
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+                        justification = "Valid output from LYV is dependent on Logback output")
     void println(final String text) {
-        this.log.info(text);
+        this.log.info("{}", text);
     }
 }
 

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
@@ -51,8 +51,8 @@ import org.slf4j.Logger;
 
 public class ModulePrinter {
 
-    private static final String REFERENCE = "reference";
-    private static final String DESCRIPTION = "description";
+    private static final String REFERENCE_STRING = "reference";
+    private static final String DESCRIPTION_STRING = "description";
 
     private final Set<TypeDefinition<?>> usedTypes;
     private final Set<String> usedImports;
@@ -349,7 +349,7 @@ public class ModulePrinter {
     private void doPrintReference(final DataSchemaNode schemaNode) {
         final Optional<String> reference = schemaNode.getReference();
         if (reference.isPresent()) {
-            printer.printSimple(REFERENCE, "\"" + reference.get() + "\"");
+            printer.printSimple(REFERENCE_STRING, "\"" + reference.get() + "\"");
             printer.printEmptyLine();
         }
     }
@@ -357,7 +357,7 @@ public class ModulePrinter {
     private void doPrintDescription(final DataSchemaNode schemaNode) {
         final Optional<String> description = schemaNode.getDescription();
         if (description.isPresent()) {
-            printer.printSimple(DESCRIPTION, "\"" + description.get() + "\"");
+            printer.printSimple(DESCRIPTION_STRING, "\"" + description.get() + "\"");
             printer.printEmptyLine();
         }
     }
@@ -393,12 +393,12 @@ public class ModulePrinter {
         }
         final Optional<String> description = module.getDescription();
         if (description.isPresent()) {
-            printer.printSimple(DESCRIPTION, "\"" + description.get() + "\"");
+            printer.printSimple(DESCRIPTION_STRING, "\"" + description.get() + "\"");
             printer.printEmptyLine();
         }
         final Optional<String> reference = module.getReference();
         if (reference.isPresent()) {
-            printer.printSimple(REFERENCE, "\"" + reference.get() + "\"");
+            printer.printSimple(REFERENCE_STRING, "\"" + reference.get() + "\"");
             printer.printEmptyLine();
         }
         final Optional<Revision> revision = module.getRevision();

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
@@ -51,7 +51,10 @@ import org.slf4j.Logger;
 
 public class ModulePrinter {
 
-    private final Set<TypeDefinition> usedTypes;
+    private static final String REFERENCE = "reference";
+    private static final String DESCRIPTION = "description";
+
+    private final Set<TypeDefinition<?>> usedTypes;
     private final Set<String> usedImports;
     private final StatementPrinter printer;
     private final Set<SchemaTree> schemaTree;
@@ -64,7 +67,7 @@ public class ModulePrinter {
     private final HashMap<GroupingDefinition, Set<SchemaTree>> groupingTreesMap = new HashMap<>();
 
     public ModulePrinter(final Set<SchemaTree> schemaTree, final SchemaContext schemaContext,
-            final QNameModule moduleName, final OutputStream out, final Set<TypeDefinition> usedTypes,
+            final QNameModule moduleName, final OutputStream out, final Set<TypeDefinition<?>> usedTypes,
             final Set<String> usedImports) {
         this(schemaTree, schemaContext, moduleName,
                 new IndentingPrinter(new PrintStream(out, false, Charset.defaultCharset())),
@@ -72,13 +75,13 @@ public class ModulePrinter {
     }
 
     public ModulePrinter(final Set<SchemaTree> schemaTree, final SchemaContext schemaContext,
-            final QNameModule moduleName, final Logger out, final Set<TypeDefinition> usedTypes,
+            final QNameModule moduleName, final Logger out, final Set<TypeDefinition<?>> usedTypes,
             final Set<String> usedImports) {
         this(schemaTree, schemaContext, moduleName, new IndentingLogger(out), usedTypes, usedImports);
     }
 
     private ModulePrinter(final Set<SchemaTree> schemaTree, final SchemaContext schemaContext,
-            final QNameModule moduleName, final Indenting printer, final Set<TypeDefinition> usedTypes,
+            final QNameModule moduleName, final Indenting printer, final Set<TypeDefinition<?>> usedTypes,
             final Set<String> usedImports) {
         this.usedImports = usedImports;
         this.usedTypes = usedTypes;
@@ -346,7 +349,7 @@ public class ModulePrinter {
     private void doPrintReference(final DataSchemaNode schemaNode) {
         final Optional<String> reference = schemaNode.getReference();
         if (reference.isPresent()) {
-            printer.printSimple("reference", "\"" + reference.get() + "\"");
+            printer.printSimple(REFERENCE, "\"" + reference.get() + "\"");
             printer.printEmptyLine();
         }
     }
@@ -354,7 +357,7 @@ public class ModulePrinter {
     private void doPrintDescription(final DataSchemaNode schemaNode) {
         final Optional<String> description = schemaNode.getDescription();
         if (description.isPresent()) {
-            printer.printSimple("description", "\"" + description.get() + "\"");
+            printer.printSimple(DESCRIPTION, "\"" + description.get() + "\"");
             printer.printEmptyLine();
         }
     }
@@ -390,12 +393,12 @@ public class ModulePrinter {
         }
         final Optional<String> description = module.getDescription();
         if (description.isPresent()) {
-            printer.printSimple("description", "\"" + description.get() + "\"");
+            printer.printSimple(DESCRIPTION, "\"" + description.get() + "\"");
             printer.printEmptyLine();
         }
         final Optional<String> reference = module.getReference();
         if (reference.isPresent()) {
-            printer.printSimple("reference", "\"" + reference.get() + "\"");
+            printer.printSimple(REFERENCE, "\"" + reference.get() + "\"");
             printer.printEmptyLine();
         }
         final Optional<Revision> revision = module.getRevision();

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/SmartTypePrintingStrategy.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/SmartTypePrintingStrategy.java
@@ -23,7 +23,7 @@ class SmartTypePrintingStrategy {
 
     private final Map<QNameModule, String> moduleToPrefix;
     private final Module module;
-    private final Set<TypeDefinition> typedefs = new TreeSet<>(Comparator.comparing(SchemaNode::getQName));
+    private final Set<TypeDefinition<?>> typedefs = new TreeSet<>(Comparator.comparing(SchemaNode::getQName));
 
     SmartTypePrintingStrategy(final Module module, final Map<QNameModule, String> moduleToPrefix) {
 
@@ -31,14 +31,14 @@ class SmartTypePrintingStrategy {
         this.moduleToPrefix = moduleToPrefix;
     }
 
-    void printTypedefs(final StatementPrinter printer, final Set<TypeDefinition> usedTypes) {
+    void printTypedefs(final StatementPrinter printer, final Set<TypeDefinition<?>> usedTypes) {
         final TypePrinter typePrinter = new TypePrinter(printer, moduleToPrefix);
         for (final TypeDefinition<?> typeDefinition : module.getTypeDefinitions()) {
             if (usedTypes.contains(typeDefinition)) {
                 typedefs.add(typeDefinition);
             }
         }
-        for (final TypeDefinition typedef : typedefs) {
+        for (final TypeDefinition<?> typedef : typedefs) {
 
             typePrinter.printTypeDef(typedef.getQName(), typedef);
         }

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/TypePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/TypePrinter.java
@@ -36,17 +36,17 @@ class TypePrinter {
         this.moduleToPrefix = moduleToPrefix;
     }
 
-    void printTypeDef(final QName name, final TypeDefinition base) {
+    void printTypeDef(final QName name, final TypeDefinition<?> base) {
         printer.openStatement(Statement.TYPEDEF, name.getLocalName());
         printType(base);
         printer.closeStatement();
     }
 
-    void printTypeUsage(final TypeDefinition type) {
+    void printTypeUsage(final TypeDefinition<?> type) {
         printer.printSimple("type", getTypeName(type));
     }
 
-    void printType(final TypeDefinition type) {
+    void printType(final TypeDefinition<?> type) {
         final String rootName = Util.getRootType(type).getQName().getLocalName();
         if (type instanceof EnumTypeDefinition) {
             final EnumTypeDefinition enumTypeDefinition = (EnumTypeDefinition) type;
@@ -150,11 +150,11 @@ class TypePrinter {
         printer.closeStatement();
     }
 
-    private void printUnion(final TypeDefinition type) {
+    private void printUnion(final TypeDefinition<?> type) {
         printer.printSimple("type", getTypeName(type));
     }
 
-    private String getTypeName(final TypeDefinition type) {
+    private String getTypeName(final TypeDefinition<?> type) {
         final String typeName;
         final String prefix = moduleToPrefix.getOrDefault(type.getQName().getModule(), "");
         if (prefix.isEmpty()) {

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/Util.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/Util.java
@@ -15,8 +15,8 @@ final class Util {
         // NO-OP
     }
 
-    static TypeDefinition getRootType(final TypeDefinition typeDefinition) {
-        TypeDefinition typeDef = typeDefinition;
+    static TypeDefinition<?> getRootType(final TypeDefinition<?> typeDefinition) {
+        TypeDefinition<?> typeDef = typeDefinition;
         while (typeDef.getBaseType() != null) {
             typeDef = typeDef.getBaseType();
         }

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -82,10 +82,8 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
 
     static {
         final TransformerFactory fa = TransformerFactory.newInstance();
-        if (!fa.getFeature(StAXResult.FEATURE)) {
-            if (!fa.getFeature(StAXResult.FEATURE)) {
-                throw new TransformerFactoryConfigurationError("No TransformerFactory supporting StAXResult found.");
-            }
+        if ((!fa.getFeature(StAXResult.FEATURE)) && (!fa.getFeature(StAXResult.FEATURE))) {
+            throw new TransformerFactoryConfigurationError("No TransformerFactory supporting StAXResult found.");
         }
 
         TRANSFORMER_FACTORY = fa;
@@ -123,7 +121,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
             IOException {
         if (reader.hasNext()) {
             reader.nextTag();
-            final AbstractNodeDataWithSchema nodeDataWithSchema;
+            final AbstractNodeDataWithSchema<?> nodeDataWithSchema;
             if (parentNode instanceof ContainerSchemaNode) {
                 nodeDataWithSchema = new ContainerNodeDataWithSchema((ContainerSchemaNode) parentNode);
             } else if (parentNode instanceof ListSchemaNode) {
@@ -164,7 +162,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
         return parse(new DOMSourceXMLStreamReader(src));
     }
 
-    private static ImmutableMap<QName, String> getElementAttributes(final XMLStreamReader in) {
+    private static ImmutableMap<QName, Object> getElementAttributes(final XMLStreamReader in) {
         checkState(in.isStartElement(), "Attributes can be extracted only from START_ELEMENT.");
         final Map<QName, String> attributes = new LinkedHashMap<>();
 
@@ -228,7 +226,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
      * @throws URISyntaxException   if the namespace URI of an XML element contains a syntax error
      */
 
-    private void read(final XMLStreamReader in, final AbstractNodeDataWithSchema parent,
+    private void read(final XMLStreamReader in, final AbstractNodeDataWithSchema<?> parent,
             final String rootElement, SchemaTree schemaTree) throws XMLStreamException, URISyntaxException {
         if (!in.hasNext()) {
             return;
@@ -448,11 +446,11 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
      * @param nsContext namespace context of the xml node which contains the {@code value}
      */
 
-    private void setValue(final AbstractNodeDataWithSchema parent, final Object value,
+    private void setValue(final AbstractNodeDataWithSchema<?> parent, final Object value,
             final NamespaceContext nsContext) {
         checkArgument(parent instanceof SimpleNodeDataWithSchema, "Node %s is not a simple type",
                 parent.getSchema().getQName());
-        final SimpleNodeDataWithSchema parentSimpleNode = (SimpleNodeDataWithSchema) parent;
+        final SimpleNodeDataWithSchema<?> parentSimpleNode = (SimpleNodeDataWithSchema<?>) parent;
         checkArgument(parentSimpleNode.getValue() == null, "Node '%s' has already set its value to '%s'",
                 parentSimpleNode.getSchema().getQName(), parentSimpleNode.getValue());
 
@@ -477,12 +475,12 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
 
         checkArgument(node instanceof TypedDataSchemaNode);
         checkArgument(value instanceof String);
-        final TypeAwareCodec xmlCodec = codecs.codecFor((TypedDataSchemaNode) node);
+        final TypeAwareCodec<?,NamespaceContext,?> xmlCodec = codecs.codecFor((TypedDataSchemaNode) node);
         return xmlCodec.parseValue(namespaceCtx, (String) value);
     }
 
-    private static AbstractNodeDataWithSchema newEntryNode(final AbstractNodeDataWithSchema parent) {
-        final AbstractNodeDataWithSchema newChild;
+    private static AbstractNodeDataWithSchema<?> newEntryNode(final AbstractNodeDataWithSchema<?> parent) {
+        final AbstractNodeDataWithSchema<?> newChild;
         if (parent instanceof ListNodeDataWithSchema) {
             newChild = ListEntryNodeDataWithSchema.forSchema((ListSchemaNode) parent.getSchema());
         } else {

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -82,7 +82,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
 
     static {
         final TransformerFactory fa = TransformerFactory.newInstance();
-        if ((!fa.getFeature(StAXResult.FEATURE)) && (!fa.getFeature(StAXResult.FEATURE))) {
+        if (!fa.getFeature(StAXResult.FEATURE)) {
             throw new TransformerFactoryConfigurationError("No TransformerFactory supporting StAXResult found.");
         }
 

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -475,7 +475,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
 
         checkArgument(node instanceof TypedDataSchemaNode);
         checkArgument(value instanceof String);
-        final TypeAwareCodec<?,NamespaceContext,?> xmlCodec = codecs.codecFor((TypedDataSchemaNode) node);
+        final TypeAwareCodec<?, NamespaceContext, ?> xmlCodec = codecs.codecFor((TypedDataSchemaNode) node);
         return xmlCodec.parseValue(namespaceCtx, (String) value);
     }
 


### PR DESCRIPTION
- Add parametrized type to generic
- Merge this if statement with the enclosing one
- Define a constant instead of duplicating this litera
- Remove deprecated class DeclaredEffectiveStatementBase
   Used AbstractDeclaredEffectiveStatement and its subclasses instead
- Use only SLF4J_SIGN_ONLY_FORMAT supress warning with
   justification and only on required methods.
- Use Collections.emptyList() insed of constat.
- Fix retun generic collection from declaredSubstatements().