### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.lighty.core</groupId>
-            <artifactId>lighty-controller</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>
             <artifactId>argparse4j</artifactId>
             <version>0.8.1</version>
@@ -105,14 +95,10 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
@@ -129,17 +115,6 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>6.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>0.9.11</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Remove unnecessary dependencies on:
 - lighty-controller
 - commons-cli
 - mockito-core
 - reflections
Distribution .zip now has only 7,1MB

Signed-off-by: marekzatko <Marek.Zatko@pantheon.tech>