### PR TITLE
Prepare for 13.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :cloud_with_lightning: lighty YANG Validator 13.2.0-SNAPSHOT
+# :cloud_with_lightning: lighty YANG Validator 13.2.0
 
 This tool validates YANG modules using the YANG-Tools parser. If there are any problems parsing the module, it will show the stacktrace with the problem, linking to the corresponding module.
 
@@ -13,14 +13,14 @@ Go to the root directory `/lighty-yang-validator/` and use the command:
 mvn clean install
 ```
 
-The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-13.2.0-SNAPSHOT-bin.zip*
+The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-13.2.0-bin.zip*
 
 ## Run from Distribution
 
 1. Unzip the distribution:
 
 ```
-unzip lighty-yang-validator-13.2.0-SNAPSHOT-bin.zip
+unzip lighty-yang-validator-13.2.0-bin.zip
 ```
 
 2. Enter the directory, to which the distribution was extracted to.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :cloud_with_lightning: lighty YANG Validator 13.1.2-SNAPSHOT
+# :cloud_with_lightning: lighty YANG Validator 13.2.0-SNAPSHOT
 
 This tool validates YANG modules using the YANG-Tools parser. If there are any problems parsing the module, it will show the stacktrace with the problem, linking to the corresponding module.
 
@@ -13,14 +13,14 @@ Go to the root directory `/lighty-yang-validator/` and use the command:
 mvn clean install
 ```
 
-The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-13.1.2-SNAPSHOT-bin.zip*
+The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-13.2.0-SNAPSHOT-bin.zip*
 
 ## Run from Distribution
 
 1. Unzip the distribution:
 
 ```
-unzip lighty-yang-validator-13.1.2-SNAPSHOT-bin.zip
+unzip lighty-yang-validator-13.2.0-SNAPSHOT-bin.zip
 ```
 
 2. Enter the directory, to which the distribution was extracted to.

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>io.lighty.yang.validator</groupId>
     <artifactId>lighty-yang-validator</artifactId>
-    <version>13.1.2-SNAPSHOT</version>
+    <version>13.2.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>YANG model validator</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>io.lighty.yang.validator</groupId>
     <artifactId>lighty-yang-validator</artifactId>
-    <version>13.2.0-SNAPSHOT</version>
+    <version>13.2.0</version>
     <name>${project.artifactId}</name>
     <description>YANG model validator</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.1.0</version>
+        <version>13.2.0</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>
@@ -108,13 +108,11 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.10</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/lighty/yang/validator/LyvParameters.java
+++ b/src/main/java/io/lighty/yang/validator/LyvParameters.java
@@ -27,7 +27,7 @@ public class LyvParameters {
 
     private final ArgumentParser lyvArgumentParser = ArgumentParsers.newFor("LYV").build()
             .defaultHelp(true)
-            .version("Version: ${prog} 13.2.0-SNAPSHOT\nContact: sales@pantheon.tech")
+            .version("Version: ${prog} 13.2.0\nContact: sales@pantheon.tech")
             .description("Yangtools based yang module parser");
     private final Format formatter;
     private final String[] args;

--- a/src/main/java/io/lighty/yang/validator/LyvParameters.java
+++ b/src/main/java/io/lighty/yang/validator/LyvParameters.java
@@ -27,7 +27,7 @@ public class LyvParameters {
 
     private final ArgumentParser lyvArgumentParser = ArgumentParsers.newFor("LYV").build()
             .defaultHelp(true)
-            .version("Version: ${prog} 13.1.2-SNAPSHOT\nContact: sales@pantheon.tech")
+            .version("Version: ${prog} 13.2.0-SNAPSHOT\nContact: sales@pantheon.tech")
             .description("Yangtools based yang module parser");
     private final Format formatter;
     private final String[] args;


### PR DESCRIPTION
Release notes:

Update upstream dependencies to latest Aluminium SR2 versions:
- yangtools 5.0.8
- commons-io 2.8.0
- testng 6.14.3

Removed unnecessary dependencies.
Update distribution process to contain fat-jar.