### PR TITLE
Prepare for release 14.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :cloud_with_lightning: lighty YANG Validator 14.0.0-SNAPSHOT
+# :cloud_with_lightning: lighty YANG Validator 14.0.0
 
 This tool validates YANG modules using the YANG-Tools parser. If there are any problems parsing the module, it will show the stacktrace with the problem, linking to the corresponding module.
 
@@ -13,14 +13,14 @@ Go to the root directory `/lighty-yang-validator/` and use the command:
 mvn clean install
 ```
 
-The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.0.0-SNAPSHOT-bin.zip*
+The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.0.0-bin.zip*
 
 ## Run from Distribution
 
 1. Unzip the distribution:
 
 ```
-unzip lighty-yang-validator-14.0.0-SNAPSHOT-bin.zip
+unzip lighty-yang-validator-14.0.0-bin.zip
 ```
 
 2. Enter the directory, to which the distribution was extracted to.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :cloud_with_lightning: lighty YANG Validator 13.2.1-SNAPSHOT
+# :cloud_with_lightning: lighty YANG Validator 14.0.0-SNAPSHOT
 
 This tool validates YANG modules using the YANG-Tools parser. If there are any problems parsing the module, it will show the stacktrace with the problem, linking to the corresponding module.
 
@@ -13,14 +13,14 @@ Go to the root directory `/lighty-yang-validator/` and use the command:
 mvn clean install
 ```
 
-The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-13.2.1-SNAPSHOT-bin.zip*
+The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.0.0-SNAPSHOT-bin.zip*
 
 ## Run from Distribution
 
 1. Unzip the distribution:
 
 ```
-unzip lighty-yang-validator-13.2.1-SNAPSHOT-bin.zip
+unzip lighty-yang-validator-14.0.0-SNAPSHOT-bin.zip
 ```
 
 2. Enter the directory, to which the distribution was extracted to.

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>13.2.0</version>
+        <version>14.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>
     <artifactId>lighty-yang-validator</artifactId>
-    <version>13.2.1-SNAPSHOT</version>
+    <version>14.0.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>YANG model validator</description>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>14.0.0-SNAPSHOT</version>
+        <version>14.0.0</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>
     <artifactId>lighty-yang-validator</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <name>${project.artifactId}</name>
     <description>YANG model validator</description>
     <packaging>jar</packaging>

--- a/src/main/java/io/lighty/yang/validator/LyvParameters.java
+++ b/src/main/java/io/lighty/yang/validator/LyvParameters.java
@@ -27,7 +27,7 @@ public class LyvParameters {
 
     private final ArgumentParser lyvArgumentParser = ArgumentParsers.newFor("LYV").build()
             .defaultHelp(true)
-            .version("Version: ${prog} 13.2.1-SNAPSHOT\nContact: sales@pantheon.tech")
+            .version("Version: ${prog} 14.0.0-SNAPSHOT\nContact: sales@pantheon.tech")
             .description("Yangtools based yang module parser");
     private final Format formatter;
     private final String[] args;

--- a/src/main/java/io/lighty/yang/validator/LyvParameters.java
+++ b/src/main/java/io/lighty/yang/validator/LyvParameters.java
@@ -27,7 +27,7 @@ public class LyvParameters {
 
     private final ArgumentParser lyvArgumentParser = ArgumentParsers.newFor("LYV").build()
             .defaultHelp(true)
-            .version("Version: ${prog} 14.0.0-SNAPSHOT\nContact: sales@pantheon.tech")
+            .version("Version: ${prog} 14.0.0\nContact: sales@pantheon.tech")
             .description("Yangtools based yang module parser");
     private final Format formatter;
     private final String[] args;

--- a/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
+++ b/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
@@ -309,8 +309,8 @@ public class CheckUpdateFrom {
         }
     }
 
-    private void checkTypeAware(TypeDefinition<? extends TypeDefinition<?>> oldType,
-                                TypeDefinition<? extends TypeDefinition<?>> newType) {
+    private void checkTypeAware(final TypeDefinition<? extends TypeDefinition<?>> oldType,
+                                final TypeDefinition<? extends TypeDefinition<?>> newType) {
         final boolean isTypeError = checkType(oldType, newType);
         checkReference(oldType.getReference(), newType.getReference());
         checkDefault(oldType, newType);
@@ -466,28 +466,28 @@ public class CheckUpdateFrom {
         final Collection<? extends MustDefinition> oldMust = ((MustConstraintAware) oldNode).getMustConstraints();
         if (oldMust.size() < newMust.size()) {
             errors.add(addedMustError().updateInformation(
-                    newNode.getPath().toString() + MUST + getXpathFromMustList(newMust),
-                    oldNode.getPath().toString() + MUST + getXpathFromMustList(oldMust)));
+                    newNode.getPath().toString() + MUST + getXpathStringFromMustCollection(newMust),
+                    oldNode.getPath().toString() + MUST + getXpathStringFromMustCollection(oldMust)));
         } else {
             for (MustDefinition newMustDefinition : newMust) {
                 if (!oldMust.contains(newMustDefinition)) {
                     errors.add(checkMustWarning().updateInformation(
                             newNode.getPath().toString() + MUST + newMustDefinition.getXpath().toString(),
-                            oldNode.getPath().toString() + MUST + getXpathFromMustList(oldMust)));
+                            oldNode.getPath().toString() + MUST + getXpathStringFromMustCollection(oldMust)));
                 }
             }
         }
     }
 
-    private String getXpathFromMustList(Collection<? extends MustDefinition> must) {
+    private String getXpathStringFromMustCollection(Collection<? extends MustDefinition> must) {
         return "[" + must.stream()
                 .map(t -> t.getXpath().toString())
                 .collect(Collectors.joining(",")) + "]";
     }
 
     private void checkWhen(final DataSchemaNode oldNode, final DataSchemaNode newNode) {
-        Optional<? extends QualifiedBound> newWhen = newNode.getWhenCondition();
-        Optional<? extends QualifiedBound> oldWhen = oldNode.getWhenCondition();
+        final Optional<? extends QualifiedBound> newWhen = newNode.getWhenCondition();
+        final Optional<? extends QualifiedBound> oldWhen = oldNode.getWhenCondition();
         if (oldWhen.isEmpty() && newWhen.isPresent()) {
             errors.add(addedWhenError().updateInformation(
                     newNode.getPath().toString() + WHEN + newWhen.get().toString(),
@@ -580,7 +580,7 @@ public class CheckUpdateFrom {
     private void checkPattern(final StringTypeDefinition oldNode, final StringTypeDefinition newNode) {
         final List<PatternConstraint> oldPatterns = oldNode.getPatternConstraints();
         final List<PatternConstraint> newPatterns = newNode.getPatternConstraints();
-        if (isPatternContainerListSame(newPatterns, oldPatterns)) {
+        if (isPatternConstraintListSame(newPatterns, oldPatterns)) {
             for (int i = 0; i < oldPatterns.size(); i++) {
                 checkReference(oldPatterns.get(i).getReference(), newPatterns.get(i).getReference());
             }
@@ -590,7 +590,7 @@ public class CheckUpdateFrom {
         }
     }
 
-    public boolean isPatternContainerListSame(final List<PatternConstraint> oldPatterns,
+    public boolean isPatternConstraintListSame(final List<PatternConstraint> oldPatterns,
             final List<PatternConstraint> newPatterns) {
         if (oldPatterns.size() != newPatterns.size()) {
             return false;
@@ -604,7 +604,7 @@ public class CheckUpdateFrom {
         return true;
     }
 
-    private boolean isPatternValuesSame(PatternConstraint newPattern, PatternConstraint oldPattern) {
+    private boolean isPatternValuesSame(final PatternConstraint newPattern, final PatternConstraint oldPattern) {
         return newPattern.getErrorMessage().equals(oldPattern.getErrorMessage())
                 && newPattern.getJavaPatternString().equals(oldPattern.getJavaPatternString())
                 && newPattern.getRegularExpressionString().equals(oldPattern.getRegularExpressionString())
@@ -613,8 +613,8 @@ public class CheckUpdateFrom {
                 && newPattern.getReference().equals(oldPattern.getReference());
     }
 
-    private String patterConstraintListToString(List<PatternConstraint> patterns) {
-        StringBuilder stringBuilder = new StringBuilder();
+    private String patterConstraintListToString(final List<PatternConstraint> patterns) {
+        final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append('[');
         for (int i = 0; i < patterns.size(); i++) {
             PatternConstraint pattern = patterns.get(i);

--- a/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
+++ b/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
@@ -66,7 +66,6 @@ import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.MustConstraintAware;
 import org.opendaylight.yangtools.yang.model.api.MustDefinition;
 import org.opendaylight.yangtools.yang.model.api.NotificationDefinition;
-import org.opendaylight.yangtools.yang.model.api.RevisionAwareXPath;
 import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 import org.opendaylight.yangtools.yang.model.api.SchemaPath;
@@ -85,6 +84,7 @@ import org.opendaylight.yangtools.yang.model.api.type.PatternConstraint;
 import org.opendaylight.yangtools.yang.model.api.type.RangeConstraint;
 import org.opendaylight.yangtools.yang.model.api.type.RangeRestrictedTypeDefinition;
 import org.opendaylight.yangtools.yang.model.api.type.StringTypeDefinition;
+import org.opendaylight.yangtools.yang.xpath.api.YangXPathExpression.QualifiedBound;
 
 public class CheckUpdateFrom {
 
@@ -480,17 +480,17 @@ public class CheckUpdateFrom {
     }
 
     private void checkWhen(final DataSchemaNode oldNode, final DataSchemaNode newNode) {
-        final Optional<RevisionAwareXPath> newWhen = newNode.getWhenCondition();
-        final Optional<RevisionAwareXPath> oldWhen = oldNode.getWhenCondition();
+        Optional<? extends QualifiedBound> newWhen = newNode.getWhenCondition();
+        Optional<? extends QualifiedBound> oldWhen = oldNode.getWhenCondition();
         if (oldWhen.isEmpty() && newWhen.isPresent()) {
             errors.add(addedWhenError().updateInformation(
-                    newNode.getPath().toString() + WHEN + newWhen.get().getOriginalString(),
+                    newNode.getPath().toString() + WHEN + newWhen.get().toString(),
                     oldNode.getPath().toString() + WHEN + DONT_EXISTS));
         } else if (oldWhen.isPresent() && newWhen.isPresent()
-                && (!oldWhen.get().getOriginalString().equals(newWhen.get().getOriginalString()))) {
+                && (!oldWhen.get().toString().equals(newWhen.get().toString()))) {
             errors.add(checkWhenWarning().updateInformation(
-                    newNode.getPath().toString() + WHEN + newWhen.get().getOriginalString(),
-                    oldNode.getPath().toString() + WHEN + oldWhen.get().getOriginalString()));
+                    newNode.getPath().toString() + WHEN + newWhen.get().toString(),
+                    oldNode.getPath().toString() + WHEN + oldWhen.get().toString()));
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
-import org.opendaylight.yangtools.yang.model.api.Module;
+import org.opendaylight.yangtools.yang.model.api.ModuleLike;
 import org.opendaylight.yangtools.yang.model.api.meta.DeclaredStatement;
 import org.opendaylight.yangtools.yang.model.api.meta.EffectiveStatement;
 import org.slf4j.Logger;
@@ -38,12 +38,12 @@ public class Analyzer extends FormatPlugin {
         printOut();
     }
 
-    private Set<DeclaredStatement<?>> getRecursivelyDeclaredStatements(final Collection<? extends Module> modules) {
+    private Set<DeclaredStatement<?>> getRecursivelyDeclaredStatements(final Collection<? extends ModuleLike> modules) {
         Set<DeclaredStatement<?>> declaredStatements = new HashSet<>();
-        for (Module module : modules) {
+        for (ModuleLike module : modules) {
             declaredStatements.add(((EffectiveStatement<?, ?>) module).getDeclared());
 
-            Collection<? extends Module> submodules = module.getSubmodules();
+            Collection<? extends ModuleLike> submodules = module.getSubmodules();
             if (submodulesAreNotEmpty(submodules)) {
                 declaredStatements.addAll(getRecursivelyDeclaredStatements(submodules));
             }
@@ -51,7 +51,7 @@ public class Analyzer extends FormatPlugin {
         return declaredStatements;
     }
 
-    private boolean submodulesAreNotEmpty(Collection<? extends Module> submodules) {
+    private boolean submodulesAreNotEmpty(Collection<? extends ModuleLike> submodules) {
         return submodules != null && !submodules.isEmpty();
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/Depends.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Depends.java
@@ -20,6 +20,7 @@ import net.sourceforge.argparse4j.impl.choice.CollectionArgumentChoice;
 import org.opendaylight.yangtools.yang.common.Revision;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.ModuleImport;
+import org.opendaylight.yangtools.yang.model.api.ModuleLike;
 import org.opendaylight.yangtools.yang.model.repo.api.RevisionSourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +78,7 @@ public class Depends extends FormatPlugin {
         }
     }
 
-    private void resolveImports(final Module module, final DependConfiguration dependConfiguration) {
+    private void resolveImports(final ModuleLike module, final DependConfiguration dependConfiguration) {
         for (ModuleImport moduleImport : module.getImports()) {
             final String moduleName = moduleImport.getModuleName();
             if (dependConfiguration.getExcludedModuleNames().contains(moduleName)) {
@@ -115,15 +116,15 @@ public class Depends extends FormatPlugin {
                 || (contextModuleRevision.toString().equals(moduleImportRevision.toString()));
     }
 
-    private void resolveSubmodules(final Module module, final DependConfiguration dependConfiguration) {
+    private void resolveSubmodules(final ModuleLike module, final DependConfiguration dependConfiguration) {
         final StringBuilder dependantsBuilder = new StringBuilder();
-        for (Module m : module.getSubmodules()) {
-            final String moduleName = m.getName();
+        for (ModuleLike subModule : module.getSubmodules()) {
+            final String moduleName = subModule.getName();
             if (dependConfiguration.getExcludedModuleNames().contains(moduleName)) {
                 continue;
             }
             dependantsBuilder.append(moduleName);
-            final Optional<Revision> revision = m.getRevision();
+            final Optional<Revision> revision = subModule.getRevision();
             if (revision.isPresent()) {
                 dependantsBuilder
                         .append(AT)
@@ -136,9 +137,9 @@ public class Depends extends FormatPlugin {
             modules.add(moduleWithRevision);
             if (!dependConfiguration.isModuleDependentsOnly()) {
                 if (!dependConfiguration.isModuleIncludesOnly()) {
-                    resolveImports(m, dependConfiguration);
+                    resolveImports(subModule, dependConfiguration);
                 }
-                resolveSubmodules(m, dependConfiguration);
+                resolveSubmodules(subModule, dependConfiguration);
             }
         }
     }

--- a/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
@@ -30,7 +30,7 @@ import org.opendaylight.yangtools.yang.model.api.AnyxmlSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.AugmentationSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.CaseSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.ChoiceSchemaNode;
-import org.opendaylight.yangtools.yang.model.api.ContainerSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.ContainerLike;
 import org.opendaylight.yangtools.yang.model.api.DataNodeContainer;
 import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.IdentitySchemaNode;
@@ -323,7 +323,7 @@ public class JsonTree extends FormatPlugin {
     private String resolveNodeClass(final DataSchemaNode node) {
         if (node instanceof ListSchemaNode) {
             return "list";
-        } else if (node instanceof ContainerSchemaNode) {
+        } else if (node instanceof ContainerLike) {
             return "container";
         } else if (node instanceof LeafListSchemaNode) {
             return "leaf-list";

--- a/src/main/java/io/lighty/yang/validator/formats/utility/LyvNodeData.java
+++ b/src/main/java/io/lighty/yang/validator/formats/utility/LyvNodeData.java
@@ -13,7 +13,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.model.api.ActionDefinition;
 import org.opendaylight.yangtools.yang.model.api.CaseSchemaNode;
-import org.opendaylight.yangtools.yang.model.api.ContainerSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.ContainerLike;
 import org.opendaylight.yangtools.yang.model.api.MandatoryAware;
 import org.opendaylight.yangtools.yang.model.api.NotificationDefinition;
 import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
@@ -47,7 +47,7 @@ public class LyvNodeData {
 
     public boolean isNodeMandatory() {
         return (this.node instanceof MandatoryAware && ((MandatoryAware) this.node).isMandatory())
-                || this.node instanceof ContainerSchemaNode || this.node instanceof CaseSchemaNode
+                || this.node instanceof ContainerLike || this.node instanceof CaseSchemaNode
                 || this.node instanceof NotificationDefinition || this.node instanceof ActionDefinition
                 || this.node instanceof RpcDefinition || this.isKey;
     }

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
@@ -37,7 +37,6 @@ import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.MandatoryAware;
 import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.ModuleImport;
-import org.opendaylight.yangtools.yang.model.api.RevisionAwareXPath;
 import org.opendaylight.yangtools.yang.model.api.SchemaContext;
 import org.opendaylight.yangtools.yang.model.api.SchemaPath;
 import org.opendaylight.yangtools.yang.model.api.TypeDefinition;
@@ -47,6 +46,7 @@ import org.opendaylight.yangtools.yang.model.api.stmt.DescriptionStatement;
 import org.opendaylight.yangtools.yang.model.api.stmt.ModuleEffectiveStatement;
 import org.opendaylight.yangtools.yang.model.api.stmt.ReferenceStatement;
 import org.opendaylight.yangtools.yang.model.api.stmt.RevisionStatement;
+import org.opendaylight.yangtools.yang.xpath.api.YangXPathExpression.QualifiedBound;
 import org.slf4j.Logger;
 
 public class ModulePrinter {
@@ -338,10 +338,10 @@ public class ModulePrinter {
     }
 
     private void doPrintWhen(final DataSchemaNode schemaNode) {
-        final Optional<RevisionAwareXPath> whenCondition = schemaNode.getWhenCondition();
+        final Optional<? extends QualifiedBound> whenCondition = schemaNode.getWhenCondition();
         if (whenCondition.isPresent()) {
             printer.printSimple("when",
-                    "\"" + whenCondition.get().getOriginalString() + "\"");
+                    "\"" + whenCondition.get().toString() + "\"");
             printer.printEmptyLine();
         }
     }

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
@@ -27,7 +27,7 @@ import org.opendaylight.yangtools.yang.common.Revision;
 import org.opendaylight.yangtools.yang.model.api.AugmentationSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.CaseSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.ChoiceSchemaNode;
-import org.opendaylight.yangtools.yang.model.api.ContainerSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.ContainerLike;
 import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.DerivableSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.GroupingDefinition;
@@ -299,7 +299,7 @@ public class ModulePrinter {
     private void doPrintSchema(final boolean isPrintingAllowed, final SchemaTree tree, final String groupingName,
             final HashMap<GroupingDefinition, Set<SchemaTree>> groupingTrees, final DataSchemaNode schemaNode) {
         if (isPrintingAllowed) {
-            if (schemaNode instanceof ContainerSchemaNode) {
+            if (schemaNode instanceof ContainerLike) {
                 printer.openStatement(Statement.CONTAINER, schemaNode.getQName().getLocalName());
                 printer.printConfig(schemaNode.isConfiguration());
             } else if (schemaNode instanceof ListSchemaNode) {

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -62,14 +62,12 @@ import org.opendaylight.yangtools.yang.data.util.SimpleNodeDataWithSchema;
 import org.opendaylight.yangtools.yang.data.util.YangModeledAnyXmlNodeDataWithSchema;
 import org.opendaylight.yangtools.yang.data.util.codec.TypeAwareCodec;
 import org.opendaylight.yangtools.yang.model.api.AnyxmlSchemaNode;
-import org.opendaylight.yangtools.yang.model.api.ContainerSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.ContainerLike;
 import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
-import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.LeafListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.LeafSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.TypedDataSchemaNode;
-import org.opendaylight.yangtools.yang.parser.stmt.reactor.EffectiveSchemaContext;
 import org.w3c.dom.Document;
 
 
@@ -125,8 +123,8 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
         if (reader.hasNext()) {
             reader.nextTag();
             final AbstractNodeDataWithSchema<?> nodeDataWithSchema;
-            if (parentNode instanceof ContainerSchemaNode) {
-                nodeDataWithSchema = new ContainerNodeDataWithSchema((ContainerSchemaNode) parentNode);
+            if (parentNode instanceof ContainerLike) {
+                nodeDataWithSchema = new ContainerNodeDataWithSchema((ContainerLike) parentNode);
             } else if (parentNode instanceof ListSchemaNode) {
                 nodeDataWithSchema = new ListNodeDataWithSchema((ListSchemaNode) parentNode);
             } else if (parentNode instanceof YangModeledAnyxmlSchemaNode) {

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -50,6 +50,7 @@ import org.opendaylight.yangtools.yang.data.codec.xml.XmlCodecFactory;
 import org.opendaylight.yangtools.yang.data.util.AbstractNodeDataWithSchema;
 import org.opendaylight.yangtools.yang.data.util.AnyXmlNodeDataWithSchema;
 import org.opendaylight.yangtools.yang.data.util.CompositeNodeDataWithSchema;
+import org.opendaylight.yangtools.yang.data.util.CompositeNodeDataWithSchema.ChildReusePolicy;
 import org.opendaylight.yangtools.yang.data.util.ContainerNodeDataWithSchema;
 import org.opendaylight.yangtools.yang.data.util.LeafListEntryNodeDataWithSchema;
 import org.opendaylight.yangtools.yang.data.util.LeafListNodeDataWithSchema;
@@ -63,10 +64,12 @@ import org.opendaylight.yangtools.yang.data.util.codec.TypeAwareCodec;
 import org.opendaylight.yangtools.yang.model.api.AnyxmlSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.ContainerSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.DataSchemaNode;
+import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.LeafListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.LeafSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.ListSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.TypedDataSchemaNode;
+import org.opendaylight.yangtools.yang.parser.stmt.reactor.EffectiveSchemaContext;
 import org.w3c.dom.Document;
 
 
@@ -336,7 +339,8 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
 
             final SchemaTree parentTree = schemaTree;
             schemaTree = getSchemaTreeWithAddedChildren(schemaTree, childDataSchemaNodes);
-            read(in, ((CompositeNodeDataWithSchema) parent).addChild(childDataSchemaNodes), rootElement, schemaTree);
+            read(in, ((CompositeNodeDataWithSchema) parent).addChild(childDataSchemaNodes, ChildReusePolicy.NOOP),
+                    rootElement, schemaTree);
             schemaTree = parentTree;
         }
     }
@@ -461,11 +465,10 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
     private static AbstractNodeDataWithSchema<?> newEntryNode(final AbstractNodeDataWithSchema<?> parent) {
         final AbstractNodeDataWithSchema<?> newChild;
         if (parent instanceof ListNodeDataWithSchema) {
-            newChild = ListEntryNodeDataWithSchema.forSchema((ListSchemaNode) parent.getSchema());
+            newChild = ((ListNodeDataWithSchema) parent).newChildEntry();
         } else {
-            newChild = new LeafListEntryNodeDataWithSchema((LeafListSchemaNode) parent.getSchema());
+            newChild = ((LeafListNodeDataWithSchema) parent).newChildEntry();
         }
-        ((CompositeNodeDataWithSchema) parent).addChild(newChild);
         return newChild;
     }
 

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -464,8 +464,10 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
         final AbstractNodeDataWithSchema<?> newChild;
         if (parent instanceof ListNodeDataWithSchema) {
             newChild = ((ListNodeDataWithSchema) parent).newChildEntry();
-        } else {
+        } else if (parent instanceof LeafListNodeDataWithSchema) {
             newChild = ((LeafListNodeDataWithSchema) parent).newChildEntry();
+        } else {
+            throw new IllegalStateException("Unsupported schema data node type " + parent.getClass() + ".");
         }
         return newChild;
     }

--- a/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
+++ b/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
@@ -51,8 +51,6 @@ public class TreeSimplifiedTest implements Cleanable {
     public void setUpOutput() throws Exception {
         this.constructor = (Constructor<Main>) Main.class.getDeclaredConstructors()[0];
         this.constructor.setAccessible(true);
-        // Just to ignore Log message from LazyLeafOperations saying "Leaf nodes are treated as transient nodes"
-        LazyLeafOperations.isEnabled();
         this.method = Main.class.getDeclaredMethod("setMainLoggerOutput", Configuration.class);
         final Main mainClass = this.constructor.newInstance();
         this.method.setAccessible(true);

--- a/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
+++ b/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.opendaylight.yangtools.yang.data.impl.schema.nodes.LazyLeafOperations;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;

--- a/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
+++ b/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
@@ -52,8 +52,6 @@ public class RFC6020Test implements Cleanable {
     public void setUpOutput() throws Exception {
         this.constructor = (Constructor<Main>) Main.class.getDeclaredConstructors()[0];
         this.constructor.setAccessible(true);
-        // Just to ignore Log message from LazyLeafOperations saying "Leaf nodes are treated as transient nodes"
-        LazyLeafOperations.isEnabled();
         this.method = Main.class.getDeclaredMethod("setMainLoggerOutput", Configuration.class);
         final Main mainClass = this.constructor.newInstance();
         this.method.setAccessible(true);

--- a/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
+++ b/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
@@ -22,7 +22,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.opendaylight.yangtools.yang.data.impl.schema.nodes.LazyLeafOperations;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;

--- a/src/test/resources/out/compare/checkUpdateFrom1
+++ b/src/test/resources/out/compare/checkUpdateFrom1
@@ -22,7 +22,7 @@ type: string
 length: [[0..4]] | Old module-> AbsoluteSchemaPath{path=[(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)string]}
 length: [[0..4], [7..10]]
 
-10 pattern error: According to RFC 6020 new patterns may be added but old ones can not be removed or changed. New module-> [EmptyPatternConstraint{regex=^(?:[0-9a-fA-F]*)$, errorAppTag=invalid-regular-expression}, EmptyPatternConstraint{regex=^(?:[0-9F]*)$, errorAppTag=invalid-regular-expression}] | Old module-> [EmptyPatternConstraint{regex=^(?:[0-9a-fA-F]*)$, errorAppTag=invalid-regular-expression}, EmptyPatternConstraint{regex=^(?:[0-9A-F]*)$, errorAppTag=invalid-regular-expression}, EmptyPatternConstraint{regex=^(?:[0-9F]*)$, errorAppTag=invalid-regular-expression}]
+10 pattern error: According to RFC 6020 new patterns may be added but old ones can not be removed or changed. New module-> [{regex=^(?:[0-9a-fA-F]*)$}, {regex=^(?:[0-9F]*)$}] | Old module-> [{regex=^(?:[0-9a-fA-F]*)$}, {regex=^(?:[0-9A-F]*)$}, {regex=^(?:[0-9F]*)$}]
 
 11 default error: According to RFC 6020 a "default" statement may be added to a leaf that does not have a default value but can not be removed or changed. New module-> does not exists | Old module-> AbsoluteSchemaPath{path=[(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)mybits]}
 default: auto-sense-speed
@@ -35,7 +35,7 @@ default: auto-sense-speed
 length: [[0..8]] | Old module-> AbsoluteSchemaPath{path=[(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)description, (urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)string]}
 length: [[0..9]]
 
-15 pattern error: According to RFC 6020 new patterns may be added but old ones can not be removed or changed. New module-> [] | Old module-> [EmptyPatternConstraint{regex=^(?:[0-9A-F]*)$, errorAppTag=invalid-regular-expression}]
+15 pattern error: According to RFC 6020 new patterns may be added but old ones can not be removed or changed. New module-> [] | Old module-> [{regex=^(?:[0-9A-F]*)$}]
 
 16 identityRef base error: According to RFC 6020 A "base" statement may be removed from an "identityref" type provided there is at least one "base" statement left. New module-> [RegularIdentityEffectiveStatement{qname=(changed:urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2019-02-20)interface-type, path=AbsoluteSchemaPath{path=[(changed:urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2019-02-20)interface-type]}}, RegularIdentityEffectiveStatement{qname=(changed:urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2019-02-20)test-identity, path=AbsoluteSchemaPath{path=[(changed:urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2019-02-20)test-identity]}}] | Old module-> [RegularIdentityEffectiveStatement{qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface-type, path=AbsoluteSchemaPath{path=[(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface-type]}}]
 


### PR DESCRIPTION
* Replace toString with method which prepare string output. Some upstream classes changed his override method toString and now return only the type of the class and not the value of his attributes.
* Replace Module class to ModuleLike clase becouse getSubmodules() method return SubModule class and not Module class like before.
* Check EffectiveSchemaContext if is instance of ContainerLike class and not ContainerSchemaNode. This interface was removed from EffectiveSchemaContext.

Release notes:

- fix FormatPlugin initialization
- Increase test coverage
- Fix code-smell reported by sonnar-cloud
- Fix bugs reported by sonnar-cloud

Update upstream dependencies to the latest Silicon versions:
- lighty.core 14.0.0
- yangtools-artifacts 6.0.5