### PR TITLE
Bump to 14.1.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :cloud_with_lightning: lighty YANG Validator 14.0.1-SNAPSHOT
+# :cloud_with_lightning: lighty YANG Validator 14.1.0-SNAPSHOT
 
 This tool validates YANG modules using the YANG-Tools parser. If there are any problems parsing the module, it will show the stacktrace with the problem, linking to the corresponding module.
 
@@ -13,14 +13,14 @@ Go to the root directory `/lighty-yang-validator/` and use the command:
 mvn clean install
 ```
 
-The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.0.1-SNAPSHOT-bin.zip*
+The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.1.0-SNAPSHOT-bin.zip*
 
 ## Run from Distribution
 
 1. Unzip the distribution:
 
 ```
-unzip lighty-yang-validator-14.0.1-SNAPSHOT-bin.zip
+unzip lighty-yang-validator-14.1.0-SNAPSHOT-bin.zip
 ```
 
 2. Enter the directory, to which the distribution was extracted to.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :cloud_with_lightning: lighty YANG Validator 14.1.0-SNAPSHOT
+# :cloud_with_lightning: lighty YANG Validator 14.1.0
 
 This tool validates YANG modules using the YANG-Tools parser. If there are any problems parsing the module, it will show the stacktrace with the problem, linking to the corresponding module.
 
@@ -13,14 +13,14 @@ Go to the root directory `/lighty-yang-validator/` and use the command:
 mvn clean install
 ```
 
-The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.1.0-SNAPSHOT-bin.zip*
+The distribution will be stored in the **"target"** directory, as a file called *lighty-yang-validator-14.1.0-bin.zip*
 
 ## Run from Distribution
 
 1. Unzip the distribution:
 
 ```
-unzip lighty-yang-validator-14.1.0-SNAPSHOT-bin.zip
+unzip lighty-yang-validator-14.1.0-bin.zip
 ```
 
 2. Enter the directory, to which the distribution was extracted to.

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>14.0.0</version>
+        <version>14.1.0</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>
     <artifactId>lighty-yang-validator</artifactId>
-    <version>14.0.1-SNAPSHOT</version>
+    <version>14.1.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>YANG model validator</description>
     <packaging>jar</packaging>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>
             <artifactId>argparse4j</artifactId>
-            <version>0.8.1</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20201115</version>
+            <version>20210307</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>io.lighty.yang.validator</groupId>
     <artifactId>lighty-yang-validator</artifactId>
-    <version>14.1.0-SNAPSHOT</version>
+    <version>14.1.0</version>
     <name>${project.artifactId}</name>
     <description>YANG model validator</description>
     <packaging>jar</packaging>

--- a/src/main/java/io/lighty/yang/validator/LyvParameters.java
+++ b/src/main/java/io/lighty/yang/validator/LyvParameters.java
@@ -27,7 +27,7 @@ public class LyvParameters {
 
     private final ArgumentParser lyvArgumentParser = ArgumentParsers.newFor("LYV").build()
             .defaultHelp(true)
-            .version("Version: ${prog} 14.0.1-SNAPSHOT\nContact: sales@pantheon.tech")
+            .version("Version: ${prog} 14.1.0-SNAPSHOT\nContact: sales@pantheon.tech")
             .description("Yangtools based yang module parser");
     private final Format formatter;
     private final String[] args;

--- a/src/main/java/io/lighty/yang/validator/LyvParameters.java
+++ b/src/main/java/io/lighty/yang/validator/LyvParameters.java
@@ -27,7 +27,7 @@ public class LyvParameters {
 
     private final ArgumentParser lyvArgumentParser = ArgumentParsers.newFor("LYV").build()
             .defaultHelp(true)
-            .version("Version: ${prog} 14.1.0-SNAPSHOT\nContact: sales@pantheon.tech")
+            .version("Version: ${prog} 14.1.0\nContact: sales@pantheon.tech")
             .description("Yangtools based yang module parser");
     private final Format formatter;
     private final String[] args;


### PR DESCRIPTION
Update upstream dependencies to the Silicon SR1 release versions:
  -  lighty.core 14.1.0
  - yangtools 6.0.6

Update dependencies to the latest versions:
 - argparse4j 0.9.0
 - json 20210307