### PR TITLE
Add empty space between submodels in depends format

### DIFF
--- a/src/main/java/io/lighty/yang/validator/formats/Depends.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Depends.java
@@ -123,6 +123,9 @@ public class Depends extends FormatPlugin {
             if (dependConfiguration.getExcludedModuleNames().contains(moduleName)) {
                 continue;
             }
+            if (dependantsBuilder.length() > 0) {
+                dependantsBuilder.append(' ');
+            }
             dependantsBuilder.append(moduleName);
             final Optional<Revision> revision = subModule.getRevision();
             if (revision.isPresent()) {

--- a/src/test/java/io/lighty/yang/validator/IntegrationTest.java
+++ b/src/test/java/io/lighty/yang/validator/IntegrationTest.java
@@ -73,7 +73,7 @@ public class IntegrationTest implements Cleanable {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/ietf-netconf-config@2013-10-21.yang", "depend");
         final String expected = "module ietf-netconf-config@2013-10-21 depends on following modules: "
                 + "ietf-inet-types ietf-netconf-acm ietf-yang-types ietf-netconf-common@2013-10-21 "
-                + "ietf-netconf-common@2013-10-21ietf-netconf-tls@2013-10-21 ietf-x509-cert-to-name \n";
+                + "ietf-netconf-common@2013-10-21 ietf-netconf-tls@2013-10-21 ietf-x509-cert-to-name \n";
         ItUtils.compareDependFormatOutput(lyvOutput, expected);
     }
 


### PR DESCRIPTION
 Changing order of loading sub-models can cause test failure. And showing submodels in this format is not a pretty:
 ietf-netconf-tls@2013-10-21ietf-netconf-common@2013-10-21

Signed-off-by: Peter Suna <peter.suna@pantheon.tech>