### PR TITLE
Bump upstream dependencies to latest upstream release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>16.0.0</version>
+        <version>16.1.0</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>


### PR DESCRIPTION
- lighty 16.1.0
- yangtools 8.0.6
