### PR TITLE
Switch GH action build to Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,11 @@ jobs:
       SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY}}
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v1
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.11
+        java-version: 17
+        distribution: 'zulu'
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       if: ${{ env.SONAR_TOKEN != 0 }}
@@ -42,7 +43,7 @@ jobs:
     - name: Maven test + SonarCloud
       if: ${{ env.SONAR_TOKEN != 0 }}
       run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-        -Dsonar.java.source=1.11
+        -Dsonar.java.source=17
         -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
         -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
         -Dsonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
We are going to switch to Java 17 for the validator 17.0.0 release.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>