### PR TITLE
Take control on logback version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,17 @@
             <version>0.9.0</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.4.4</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-parser-impl</artifactId>
         </dependency>
@@ -89,10 +100,6 @@
         <dependency>
             <groupId>org.opendaylight.yangtools</groupId>
             <artifactId>yang-parser-rfc7950</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>


### PR DESCRIPTION
Take control on logback version used in validator. Previously, the version was inherited from odlparent or lighty core.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>