### PR TITLE
Perform basic cleanups

### DIFF
--- a/src/main/java/io/lighty/yang/validator/config/ConfigurationBuilder.java
+++ b/src/main/java/io/lighty/yang/validator/config/ConfigurationBuilder.java
@@ -15,19 +15,14 @@ import net.sourceforge.argparse4j.inf.Namespace;
 import org.opendaylight.yangtools.yang.common.QName;
 
 public class ConfigurationBuilder {
-
-    private final Configuration configuration;
-
-    public ConfigurationBuilder() {
-        this.configuration = new Configuration();
-    }
+    private final Configuration configuration = new Configuration();
 
     public ConfigurationBuilder setTreeConfiguration(final int treeDepth, final int lineLength,
             final boolean help, final boolean modulePrefix,
             final boolean treePrefixMainModule) {
         final TreeConfiguration treeConfiguration = new TreeConfiguration(treeDepth, lineLength, help,
                 modulePrefix, treePrefixMainModule);
-        this.configuration.setTreeConfiguration(treeConfiguration);
+        configuration.setTreeConfiguration(treeConfiguration);
         return this;
     }
 
@@ -37,12 +32,12 @@ public class ConfigurationBuilder {
             final Set<String> excludedModuleNames) {
         final DependConfiguration dependConfiguration = new DependConfiguration(moduleDependentsOnly,
                 moduleImportsOnly, moduleIncludesOnly, excludedModuleNames);
-        this.configuration.setDependConfiguration(dependConfiguration);
+        configuration.setDependConfiguration(dependConfiguration);
         return this;
     }
 
     public ConfigurationBuilder setUpdateFrom(final String checkUpdateFrom) {
-        this.configuration.setUpdateFrom(checkUpdateFrom);
+        configuration.setUpdateFrom(checkUpdateFrom);
         return this;
     }
 
@@ -50,78 +45,78 @@ public class ConfigurationBuilder {
             final List<String> checkUpdateFromPath) {
         final CheckUpdateFromConfiguration checkUpdateFromConfiguration =
                 new CheckUpdateFromConfiguration(rfcVersion, checkUpdateFromPath);
-        this.configuration.setCheckUpdateFromConfiguration(checkUpdateFromConfiguration);
+        configuration.setCheckUpdateFromConfiguration(checkUpdateFromConfiguration);
         return this;
     }
 
     public ConfigurationBuilder setSupportedFeatures(final List<Object> features) {
-        this.configuration.setSupportedFeatures(resolveSupportedFeatures(features));
+        configuration.setSupportedFeatures(resolveSupportedFeatures(features));
         return this;
     }
 
     public ConfigurationBuilder setModuleNames(final List<String> moduleNames) {
-        this.configuration.setModuleNames(moduleNames);
+        configuration.setModuleNames(moduleNames);
         return this;
     }
 
     public ConfigurationBuilder setOutput(final String output) {
-        this.configuration.setOutput(output);
+        configuration.setOutput(output);
         return this;
     }
 
     public ConfigurationBuilder setDebug(final boolean debug) {
-        this.configuration.setDebug(debug);
+        configuration.setDebug(debug);
         return this;
     }
 
     public ConfigurationBuilder setQuiet(final boolean quiet) {
-        this.configuration.setQuiet(quiet);
+        configuration.setQuiet(quiet);
         return this;
     }
 
     public ConfigurationBuilder setPath(final List<String> path) {
-        this.configuration.setPath(path);
+        configuration.setPath(path);
         return this;
     }
 
     public ConfigurationBuilder setYangModules(final List<String> yang) {
-        this.configuration.setYangModules(yang);
+        configuration.setYangModules(yang);
         return this;
     }
 
     public ConfigurationBuilder setRecursive(final boolean recursive) {
-        this.configuration.setRecursive(recursive);
+        configuration.setRecursive(recursive);
         return this;
     }
 
     public ConfigurationBuilder setFormat(final String format) {
-        this.configuration.setFormat(format);
+        configuration.setFormat(format);
         return this;
     }
 
     public ConfigurationBuilder setSimplify(final String simplify) {
-        this.configuration.setSimplify(simplify);
+        configuration.setSimplify(simplify);
         return this;
     }
 
     public ConfigurationBuilder setParseAll(final List<String> parseAll) {
-        this.configuration.setParseAll(parseAll);
+        configuration.setParseAll(parseAll);
         return this;
     }
 
     public ConfigurationBuilder from(final LyvParameters params) {
         final Namespace namespace = params.parseArguments();
-        this.configuration.setSupportedFeatures(resolveSupportedFeatures(namespace.getList("features")));
-        this.configuration.setModuleNames(namespace.getList("module_name"));
-        this.configuration.setOutput(namespace.getString("output"));
-        this.configuration.setDebug(namespace.getBoolean("debug"));
-        this.configuration.setQuiet(namespace.getBoolean("quiet"));
-        this.configuration.setPath(namespace.getList("path"));
-        this.configuration.setYangModules(namespace.getList("yang"));
-        this.configuration.setRecursive(namespace.getBoolean("recursive"));
-        this.configuration.setFormat(namespace.getString("format"));
-        this.configuration.setSimplify(namespace.getString("simplify"));
-        this.configuration.setParseAll(namespace.getList("parse_all"));
+        configuration.setSupportedFeatures(resolveSupportedFeatures(namespace.getList("features")));
+        configuration.setModuleNames(namespace.getList("module_name"));
+        configuration.setOutput(namespace.getString("output"));
+        configuration.setDebug(namespace.getBoolean("debug"));
+        configuration.setQuiet(namespace.getBoolean("quiet"));
+        configuration.setPath(namespace.getList("path"));
+        configuration.setYangModules(namespace.getList("yang"));
+        configuration.setRecursive(namespace.getBoolean("recursive"));
+        configuration.setFormat(namespace.getString("format"));
+        configuration.setSimplify(namespace.getString("simplify"));
+        configuration.setParseAll(namespace.getList("parse_all"));
         final boolean singleModuledependentsOnly = namespace.getBoolean("module_depends_only");
         final boolean modulesOnly = namespace.getBoolean("modules_only");
         final boolean submodulesOnly = namespace.getBoolean("submodules_only");
@@ -135,16 +130,16 @@ public class ConfigurationBuilder {
         final boolean treePrefixMainModule = namespace.getBoolean("tree_prefix_main_module");
         final TreeConfiguration treeConfiguration = new TreeConfiguration(treeDepth, lineLength, treeHelp,
                 treeModulePrefix, treePrefixMainModule);
-        this.configuration.setTreeConfiguration(treeConfiguration);
-        this.configuration.setDependConfiguration(dependConfiguration);
-        this.configuration.setUpdateFrom(namespace.getString("check_update_from"));
+        configuration.setTreeConfiguration(treeConfiguration);
+        configuration.setDependConfiguration(dependConfiguration);
+        configuration.setUpdateFrom(namespace.getString("check_update_from"));
         final CheckUpdateFromConfiguration checkUpdateFromConfiguration = new CheckUpdateFromConfiguration(
                 namespace.getInt("rfc_version"), namespace.getList("check_update_from_path"));
-        this.configuration.setCheckUpdateFromConfiguration(checkUpdateFromConfiguration);
+        configuration.setCheckUpdateFromConfiguration(checkUpdateFromConfiguration);
         return this;
     }
 
-    private Set<QName> resolveSupportedFeatures(final List<Object> features) {
+    private static Set<QName> resolveSupportedFeatures(final List<Object> features) {
         Set<QName> supportedFeatures = null;
         if (features != null) {
             supportedFeatures = new HashSet<>();

--- a/src/main/java/io/lighty/yang/validator/exceptions/LyvApplicationException.java
+++ b/src/main/java/io/lighty/yang/validator/exceptions/LyvApplicationException.java
@@ -1,6 +1,8 @@
 package io.lighty.yang.validator.exceptions;
 
 public class LyvApplicationException extends Exception {
+    @java.io.Serial
+    private static final long serialVersionUID = 2775131351016822902L;
 
     public LyvApplicationException(final String message) {
         super(message);

--- a/src/main/java/io/lighty/yang/validator/exceptions/NotFoundException.java
+++ b/src/main/java/io/lighty/yang/validator/exceptions/NotFoundException.java
@@ -5,6 +5,8 @@ package io.lighty.yang.validator.exceptions;
  * found.
  */
 public class NotFoundException extends RuntimeException {
+    @java.io.Serial
+    private static final long serialVersionUID = -850705943805156370L;
 
     public NotFoundException(final String customMessage, final String name) {
         super(customMessage + ", " + name + " not found.");

--- a/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
@@ -31,7 +31,7 @@ public class Analyzer extends FormatPlugin {
 
     @Override
     void emitFormat() {
-        final Set<DeclaredStatement<?>> statements = getRecursivelyDeclaredStatements(this.schemaContext.getModules());
+        final Set<DeclaredStatement<?>> statements = getRecursivelyDeclaredStatements(schemaContext.getModules());
         for (final DeclaredStatement<?> declaredStatement : statements) {
             analyzeSubstatement(declaredStatement);
         }
@@ -51,21 +51,21 @@ public class Analyzer extends FormatPlugin {
         return declaredStatements;
     }
 
-    private boolean submodulesAreNotEmpty(final Collection<? extends ModuleLike> submodules) {
+    private static boolean submodulesAreNotEmpty(final Collection<? extends ModuleLike> submodules) {
         return submodules != null && !submodules.isEmpty();
     }
 
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     private void printOut() {
-        for (final Map.Entry<String, Integer> entry : new TreeMap<>(this.counter).entrySet()) {
+        for (final Map.Entry<String, Integer> entry : new TreeMap<>(counter).entrySet()) {
             LOG.info("{}: {}", entry.getKey(), entry.getValue());
         }
     }
 
     private void analyzeSubstatement(final DeclaredStatement<?> subStatement) {
         final String name = subStatement.statementDefinition().getStatementName().getLocalName();
-        counter.compute(name, (key, val) -> (val == null) ? 1 : val + 1);
+        counter.compute(name, (key, val) -> val == null ? 1 : val + 1);
         final Collection<? extends DeclaredStatement<?>> substatements = subStatement.declaredSubstatements();
         for (final DeclaredStatement<?> nextSubstatement : substatements) {
             analyzeSubstatement(nextSubstatement);

--- a/src/main/java/io/lighty/yang/validator/formats/ConsoleLine.java
+++ b/src/main/java/io/lighty/yang/validator/formats/ConsoleLine.java
@@ -32,21 +32,22 @@ public class ConsoleLine extends Line {
         this.isConnected = isConnected;
     }
 
+    @Override
     protected void resolveFlag(SchemaNode node, final Absolute absolutePath, EffectiveModelContext context) {
         if (node instanceof CaseSchemaNode) {
-            this.flag = "";
+            flag = "";
         } else if (node instanceof NotificationDefinition) {
-            this.flag = "-n";
+            flag = "-n";
         } else if (context.findNotification(absolutePath.firstNodeIdentifier()).isPresent()) {
-            this.flag = RO;
-        } else if (this.inputOutput == RpcInputOutput.INPUT) {
-            this.flag = "-w";
-        } else if (this.inputOutput == RpcInputOutput.OUTPUT) {
-            this.flag = RO;
+            flag = RO;
+        } else if (inputOutput == RpcInputOutput.INPUT) {
+            flag = "-w";
+        } else if (inputOutput == RpcInputOutput.OUTPUT) {
+            flag = RO;
         } else if (node instanceof DataSchemaNode) {
             resolveFlagForDataSchemaNode((DataSchemaNode) node, RW, RO);
         } else {
-            this.flag = "-x";
+            flag = "-x";
         }
     }
 
@@ -82,7 +83,7 @@ public class ConsoleLine extends Line {
         return builder.toString();
     }
 
-    private StringBuilder getBuilderWithRestOfTheFeature(final Iterator<IfFeatureStatement> ifFeaturesIterator) {
+    private static StringBuilder getBuilderWithRestOfTheFeature(final Iterator<IfFeatureStatement> ifFeaturesIterator) {
         final StringBuilder builder = new StringBuilder();
         builder.append(" {");
         while (ifFeaturesIterator.hasNext()) {

--- a/src/main/java/io/lighty/yang/validator/formats/Depends.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Depends.java
@@ -45,9 +45,9 @@ public class Depends extends FormatPlugin {
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
-        final DependConfiguration dependConfiguration = this.configuration.getDependConfiguration();
-        for (final SourceIdentifier source : this.sources) {
-            final Module module = this.schemaContext.findModule(source.name().getLocalName(), source.revision())
+        final DependConfiguration dependConfiguration = configuration.getDependConfiguration();
+        for (final SourceIdentifier source : sources) {
+            final Module module = schemaContext.findModule(source.name().getLocalName(), source.revision())
                     .orElseThrow(() -> new NotFoundException("Module", source.name().getLocalName()));
             final StringBuilder dependantsBuilder = new StringBuilder(MODULE);
             dependantsBuilder.append(module.getName())
@@ -90,7 +90,7 @@ public class Depends extends FormatPlugin {
 
     private void resolveImportsInSchemaContextModules(final DependConfiguration dependConfiguration,
             final ModuleImport moduleImport, final String moduleName) {
-        for (final Module contextModule : this.schemaContext.getModules()) {
+        for (final Module contextModule : schemaContext.getModules()) {
             if (moduleName.equals(contextModule.getName()) && isRevisionsEqualsOrNull(moduleImport, contextModule)) {
                 addContextModuleToModulesAndResolveImports(dependConfiguration, contextModule);
                 break;
@@ -109,11 +109,11 @@ public class Depends extends FormatPlugin {
         }
     }
 
-    private boolean isRevisionsEqualsOrNull(final ModuleImport moduleImport, final Module contextModule) {
+    private static boolean isRevisionsEqualsOrNull(final ModuleImport moduleImport, final Module contextModule) {
         final Revision moduleImportRevision = moduleImport.getRevision().orElse(null);
         final Revision contextModuleRevision = contextModule.getRevision().orElse(null);
-        return (moduleImportRevision == null || contextModuleRevision == null)
-                || (contextModuleRevision.toString().equals(moduleImportRevision.toString()));
+        return moduleImportRevision == null || contextModuleRevision == null
+                || contextModuleRevision.toString().equals(moduleImportRevision.toString());
     }
 
     private void resolveSubmodules(final ModuleLike module, final DependConfiguration dependConfiguration) {

--- a/src/main/java/io/lighty/yang/validator/formats/HtmlLine.java
+++ b/src/main/java/io/lighty/yang/validator/formats/HtmlLine.java
@@ -78,7 +78,7 @@ public class HtmlLine extends Line {
                 }
             } else {
                 return SchemaHtmlEnum.getSchemaHtmlEnumByName(
-                        ((EffectiveStatement) node).getDeclared().statementDefinition().getStatementName()
+                        ((EffectiveStatement<?, ?>) node).getDeclared().statementDefinition().getStatementName()
                                 .getLocalName());
             }
         } else {
@@ -172,17 +172,17 @@ public class HtmlLine extends Line {
         if (node instanceof CaseSchemaNode || node instanceof RpcDefinition || node instanceof NotificationDefinition
                 || node instanceof ActionDefinition) {
             // do not emit the "config/no config" for rpc/action/notification/case SchemaNode
-            this.flag = "";
+            flag = "";
         } else if (context.findNotification(absolutePath.firstNodeIdentifier()).isPresent()) {
-            this.flag = NO_CONFIG;
-        } else if (this.inputOutput == RpcInputOutput.INPUT) {
-            this.flag = CONFIG;
-        } else if (this.inputOutput == RpcInputOutput.OUTPUT) {
-            this.flag = NO_CONFIG;
+            flag = NO_CONFIG;
+        } else if (inputOutput == RpcInputOutput.INPUT) {
+            flag = CONFIG;
+        } else if (inputOutput == RpcInputOutput.OUTPUT) {
+            flag = NO_CONFIG;
         } else if (node instanceof DataSchemaNode) {
             resolveFlagForDataSchemaNode((DataSchemaNode) node, CONFIG, NO_CONFIG);
         } else {
-            this.flag = CONFIG;
+            flag = CONFIG;
         }
     }
 }

--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -56,9 +56,9 @@ public class JsTree extends FormatPlugin {
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
-        this.namespacePrefix = new HashMap<>();
-        for (final SourceIdentifier source : this.sources) {
-            final Module module = this.schemaContext.findModule(source.name().getLocalName(), source.revision())
+        namespacePrefix = new HashMap<>();
+        for (final SourceIdentifier source : sources) {
+            final Module module = schemaContext.findModule(source.name().getLocalName(), source.revision())
                     .orElseThrow(() -> new NotFoundException("Module", source.name().getLocalName()));
             final SingletonListInitializer singletonListInitializer = new SingletonListInitializer(1);
 
@@ -87,7 +87,7 @@ public class JsTree extends FormatPlugin {
 
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
-    private void printLines(final List<Line> lines) {
+    private static void printLines(final List<Line> lines) {
         for (final Line line : lines) {
             LOG.info("{}", line);
         }
@@ -96,11 +96,11 @@ public class JsTree extends FormatPlugin {
     private List<Line> getNotificationsLines(final SingletonListInitializer singletonListInitializer,
             final Module module) {
         final List<Line> lines = new ArrayList<>();
-        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(this.schemaContext);
+        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(schemaContext);
         for (final NotificationDefinition node : module.getNotifications()) {
             schemaIS.enterSchemaTree(node.getQName());
             final List<Integer> ids = singletonListInitializer.getSingletonListWithIncreasedValue();
-            final LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, node, Collections.emptyList(),
+            final LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, node, Collections.emptyList(),
                     schemaIS.toSchemaNodeIdentifier());
             final HtmlLine htmlLine = new HtmlLine(new ArrayList<>(ids), lyvNodeData, RpcInputOutput.OTHER,
                     namespacePrefix);
@@ -114,11 +114,11 @@ public class JsTree extends FormatPlugin {
 
     private List<Line> getRpcsLines(final SingletonListInitializer singletonListInitializer, final Module module) {
         final List<Line> lines = new ArrayList<>();
-        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(this.schemaContext);
+        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(schemaContext);
         for (final RpcDefinition node : module.getRpcs()) {
             schemaIS.enterSchemaTree(node.getQName());
             final List<Integer> rpcId = singletonListInitializer.getSingletonListWithIncreasedValue();
-            LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, node, Collections.emptyList(),
+            LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, node, Collections.emptyList(),
                     schemaIS.toSchemaNodeIdentifier());
             HtmlLine htmlLine = new HtmlLine(rpcId, lyvNodeData, RpcInputOutput.OTHER, namespacePrefix);
             lines.add(htmlLine);
@@ -128,7 +128,7 @@ public class JsTree extends FormatPlugin {
             if (inputExists) {
                 ids.add(1);
                 schemaIS.enterSchemaTree(node.getInput().getQName());
-                lyvNodeData = new LyvNodeData(this.schemaContext, node.getInput(), Collections.emptyList(),
+                lyvNodeData = new LyvNodeData(schemaContext, node.getInput(), Collections.emptyList(),
                         schemaIS.toSchemaNodeIdentifier());
                 htmlLine = new HtmlLine(new ArrayList<>(ids), lyvNodeData, RpcInputOutput.INPUT, namespacePrefix);
                 lines.add(htmlLine);
@@ -144,7 +144,7 @@ public class JsTree extends FormatPlugin {
                     ids.add(2);
                 }
                 schemaIS.enterSchemaTree(node.getOutput().getQName());
-                lyvNodeData = new LyvNodeData(this.schemaContext, node.getOutput(), Collections.emptyList(),
+                lyvNodeData = new LyvNodeData(schemaContext, node.getOutput(), Collections.emptyList(),
                         schemaIS.toSchemaNodeIdentifier());
                 htmlLine = new HtmlLine(new ArrayList<>(ids), lyvNodeData, RpcInputOutput.OUTPUT, namespacePrefix);
                 lines.add(htmlLine);
@@ -164,16 +164,16 @@ public class JsTree extends FormatPlugin {
         final List<Line> lines = new ArrayList<>();
         final String headerText = prepareHeader(module);
         LOG.info("{}", headerText);
-        for (final Module m : this.schemaContext.getModules()) {
+        for (final Module m : schemaContext.getModules()) {
             if (!m.getPrefix().equals(module.getPrefix())) {
                 namespacePrefix.put(m.getNamespace(), m.getPrefix());
             }
         }
-        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(this.schemaContext);
+        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(schemaContext);
         for (final DataSchemaNode node : module.getChildNodes()) {
             schemaIS.enterSchemaTree(node.getQName());
             final List<Integer> ids = singletonListInitializer.getSingletonListWithIncreasedValue();
-            final LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, node, Collections.emptyList(),
+            final LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, node, Collections.emptyList(),
                     schemaIS.toSchemaNodeIdentifier());
             final HtmlLine htmlLine = new HtmlLine(ids, lyvNodeData, RpcInputOutput.OTHER, namespacePrefix);
             lines.add(htmlLine);
@@ -186,25 +186,23 @@ public class JsTree extends FormatPlugin {
 
     private List<Line> getAugmentationNodesLines(final List<Integer> ids, final AugmentationSchemaNode augNode) {
         final List<Line> lines = new ArrayList<>();
-        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(this.schemaContext);
+        final SchemaInferenceStack schemaIS = SchemaInferenceStack.of(schemaContext);
         schemaIS.enterSchemaTree(augNode.getTargetPath());
         final DataSchemaNode dataSchemaNode = augNode.getChildNodes().iterator().next();
         schemaIS.enterSchemaTree(dataSchemaNode.getQName());
-        LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, dataSchemaNode,
+        LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, dataSchemaNode,
                 Collections.emptyList(), schemaIS.toSchemaNodeIdentifier());
         final HtmlLine htmlLine = new HtmlLine(new ArrayList<>(ids), lyvNodeData, RpcInputOutput.OTHER, namespacePrefix,
                 augNode);
         lines.add(htmlLine);
         schemaIS.exit();
-        final Iterator<? extends DataSchemaNode> nodes = augNode.getChildNodes().iterator();
         int modelAugmentationNumber = 1;
-        while (nodes.hasNext()) {
-            final DataSchemaNode node = nodes.next();
+        for (DataSchemaNode node : augNode.getChildNodes()) {
             schemaIS.enterSchemaTree(node.getQName());
             final List<QName> qnames = schemaIS.toSchemaNodeIdentifier().getNodeIdentifiers();
             final RpcInputOutput inputOutputOther = getAugmentationRpcInputOutput(qnames);
             ids.add(modelAugmentationNumber++);
-            lyvNodeData = new LyvNodeData(this.schemaContext, node, Collections.emptyList(),
+            lyvNodeData = new LyvNodeData(schemaContext, node, Collections.emptyList(),
                     schemaIS.toSchemaNodeIdentifier());
             final HtmlLine line = new HtmlLine(new ArrayList<>(ids), lyvNodeData, inputOutputOther, namespacePrefix);
             lines.add(line);
@@ -223,16 +221,16 @@ public class JsTree extends FormatPlugin {
         for (int i = 1; i <= qnames.size(); i++) {
             final List<QName> qnamesCopy = qnames.subList(0, i);
             inputOutputOther = getRpcInputOutput(qnames, actions, inputOutputOther, i, qnamesCopy);
-            if (this.schemaContext.findDataTreeChild(qnamesCopy).get() instanceof ActionNodeContainer) {
+            if (schemaContext.findDataTreeChild(qnamesCopy).get() instanceof ActionNodeContainer) {
                 final ActionNodeContainer actionSchemaNode =
-                        (ActionNodeContainer) this.schemaContext.findDataTreeChild(qnamesCopy).get();
+                        (ActionNodeContainer) schemaContext.findDataTreeChild(qnamesCopy).get();
                 actions = actionSchemaNode.getActions();
             }
         }
         return inputOutputOther;
     }
 
-    private RpcInputOutput getRpcInputOutput(final List<QName> qnames,
+    private static RpcInputOutput getRpcInputOutput(final List<QName> qnames,
             final Collection<? extends ActionDefinition> actions, final RpcInputOutput inputOutputOther,
             final int iteration, final List<QName> qnamesCopy) {
         if (actions.isEmpty()) {
@@ -250,7 +248,7 @@ public class JsTree extends FormatPlugin {
         return inputOutputOther;
     }
 
-    private String loadJS() {
+    private static String loadJS() {
         final URL url = Resources.getResource("js");
         String text = "";
         try {
@@ -262,7 +260,7 @@ public class JsTree extends FormatPlugin {
         return text;
     }
 
-    private String prepareHeader(final Module module) {
+    private static String prepareHeader(final Module module) {
         final StringBuilder nameRevision = new StringBuilder(module.getName());
         module.getRevision().ifPresent(value -> nameRevision.append("@").append(value));
         final URL url = Resources.getResource("header");
@@ -303,7 +301,7 @@ public class JsTree extends FormatPlugin {
             connections.add(0);
             connections.set(connections.size() - 1, id);
             schemaIS.enterSchemaTree(action.getQName());
-            LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, action, Collections.emptyList(),
+            LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, action, Collections.emptyList(),
                     schemaIS.toSchemaNodeIdentifier());
             HtmlLine htmlLine = new HtmlLine(new ArrayList<>(connections), lyvNodeData, RpcInputOutput.OTHER,
                     namespacePrefix);
@@ -313,7 +311,7 @@ public class JsTree extends FormatPlugin {
             if (inputExists) {
                 connections.add(1);
                 schemaIS.enterSchemaTree(action.getInput().getQName());
-                lyvNodeData = new LyvNodeData(this.schemaContext, action.getInput(), Collections.emptyList(),
+                lyvNodeData = new LyvNodeData(schemaContext, action.getInput(), Collections.emptyList(),
                         schemaIS.toSchemaNodeIdentifier());
                 htmlLine = new HtmlLine(new ArrayList<>(connections), lyvNodeData, RpcInputOutput.INPUT,
                         namespacePrefix);
@@ -326,7 +324,7 @@ public class JsTree extends FormatPlugin {
             if (outputExists) {
                 connections.add(1);
                 schemaIS.enterSchemaTree(action.getOutput().getQName());
-                lyvNodeData = new LyvNodeData(this.schemaContext, action.getOutput(), Collections.emptyList(),
+                lyvNodeData = new LyvNodeData(schemaContext, action.getOutput(), Collections.emptyList(),
                         schemaIS.toSchemaNodeIdentifier());
                 htmlLine = new HtmlLine(new ArrayList<>(connections), lyvNodeData, RpcInputOutput.OUTPUT,
                         namespacePrefix);
@@ -348,7 +346,7 @@ public class JsTree extends FormatPlugin {
             final DataSchemaNode child = iterator.next();
             schemaIS.enterSchemaTree(child.getQName());
             connections.set(connections.size() - 1, id++);
-            final LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, child, Collections.emptyList(),
+            final LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, child, Collections.emptyList(),
                     schemaIS.toSchemaNodeIdentifier());
             final HtmlLine htmlLine = new HtmlLine(new ArrayList<>(connections), lyvNodeData, inputOutput,
                     namespacePrefix);
@@ -370,7 +368,7 @@ public class JsTree extends FormatPlugin {
             final DataSchemaNode child = childNodes.next();
             schemaIS.enterSchemaTree(child.getQName());
             connections.set(connections.size() - 1, id++);
-            final LyvNodeData lyvNodeData = new LyvNodeData(this.schemaContext, child, keys,
+            final LyvNodeData lyvNodeData = new LyvNodeData(schemaContext, child, keys,
                     schemaIS.toSchemaNodeIdentifier());
             final HtmlLine htmlLine = new HtmlLine(new ArrayList<>(connections), lyvNodeData, inputOutput,
                     namespacePrefix);
@@ -403,11 +401,11 @@ public class JsTree extends FormatPlugin {
         private int id;
 
         SingletonListInitializer(final int initialValue) {
-            this.id = initialValue;
+            id = initialValue;
         }
 
         List<Integer> getSingletonListWithIncreasedValue() {
-            return new ArrayList<>(Collections.singletonList(this.id++));
+            return new ArrayList<>(Collections.singletonList(id++));
         }
     }
 }

--- a/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
@@ -96,12 +96,12 @@ public class JsonTree extends FormatPlugin {
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
-        for (final SourceIdentifier source : this.sources) {
-            final Module module = this.schemaContext.findModule(source.name().getLocalName(), source.revision())
+        for (final SourceIdentifier source : sources) {
+            final Module module = schemaContext.findModule(source.name().getLocalName(), source.revision())
                     .orElseThrow(() -> new NotFoundException(MODULE_STRING, source.name().getLocalName()));
             final JSONObject moduleMetadata = resolveModuleMetadata(module);
             final JSONObject jsonTree = new JSONObject();
-            final SchemaInferenceStack schemaInferenceStack = SchemaInferenceStack.of(this.schemaContext);
+            final SchemaInferenceStack schemaInferenceStack = SchemaInferenceStack.of(schemaContext);
             appendChildNodesToJsonTree(module, jsonTree, schemaInferenceStack);
             appendNotificationsToJsonTree(module, jsonTree, schemaInferenceStack);
             appendRpcsToJsonTree(module, jsonTree, schemaInferenceStack);
@@ -204,7 +204,7 @@ public class JsonTree extends FormatPlugin {
         }
     }
 
-    private void putNotificationDataToJsonNotification(final NotificationDefinition notification,
+    private static void putNotificationDataToJsonNotification(final NotificationDefinition notification,
             final JSONObject jsonNotification, final SchemaInferenceStack schemaInferenceStack) {
         jsonNotification.put(NAME, notification.getQName().getLocalName());
         jsonNotification.put(DESCRIPTION, notification.getDescription().orElse(EMPTY));
@@ -251,7 +251,8 @@ public class JsonTree extends FormatPlugin {
         return true;
     }
 
-    private boolean shouldSkipThisIteration(final Collection<? extends ActionDefinition> actions, final QName path) {
+    private static boolean shouldSkipThisIteration(final Collection<? extends ActionDefinition> actions,
+            final QName path) {
         for (final ActionDefinition action : actions) {
             if (action.getQName().getLocalName().equals(path.getLocalName())) {
                 return true;
@@ -339,7 +340,7 @@ public class JsonTree extends FormatPlugin {
         return jsonLeafType;
     }
 
-    private String resolveNodeClass(final DataSchemaNode node) {
+    private static String resolveNodeClass(final DataSchemaNode node) {
         if (node instanceof ListSchemaNode) {
             return "list";
         } else if (node instanceof ContainerLike) {
@@ -362,7 +363,7 @@ public class JsonTree extends FormatPlugin {
         }
     }
 
-    private JSONObject resolveModuleMetadata(final Module module) {
+    private static JSONObject resolveModuleMetadata(final Module module) {
         final JSONObject jsonModuleMetadata = new JSONObject();
         jsonModuleMetadata.put(NAME, module.getName());
         jsonModuleMetadata.put(REVISION, module.getRevision().orElse(Revision.of(EARLIEST_REVISION)).toString());

--- a/src/main/java/io/lighty/yang/validator/formats/Line.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Line.java
@@ -9,7 +9,6 @@ package io.lighty.yang.validator.formats;
 
 import io.lighty.yang.validator.formats.utility.LyvNodeData;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.opendaylight.yangtools.yang.common.QName;
@@ -59,12 +58,12 @@ abstract class Line {
     Line(final LyvNodeData lyvNodeData, final RpcInputOutput inputOutput,
             final Map<XMLNamespace, String> namespacePrefix) {
         final SchemaNode node = lyvNodeData.getNode();
-        this.status = node.getStatus();
-        this.isMandatory = lyvNodeData.isNodeMandatory();
-        this.isListOrLeafList = node instanceof LeafListSchemaNode || node instanceof ListSchemaNode;
-        this.isChoice = node instanceof ChoiceSchemaNode;
-        this.isCase = node instanceof CaseSchemaNode;
-        this.nodeName = node.getQName().getLocalName();
+        status = node.getStatus();
+        isMandatory = lyvNodeData.isNodeMandatory();
+        isListOrLeafList = node instanceof LeafListSchemaNode || node instanceof ListSchemaNode;
+        isChoice = node instanceof ChoiceSchemaNode;
+        isCase = node instanceof CaseSchemaNode;
+        nodeName = node.getQName().getLocalName();
         this.inputOutput = inputOutput;
         this.namespacePrefix = namespacePrefix;
         resolveFlag(node, lyvNodeData.getAbsolutePath(), lyvNodeData.getContext());
@@ -78,24 +77,23 @@ abstract class Line {
     protected void resolveFlagForDataSchemaNode(final DataSchemaNode dataSchemaNode, final String config,
             final String noConfig) {
         if (dataSchemaNode.isConfiguration()) {
-            this.flag = config;
+            flag = config;
         } else {
-            this.flag = noConfig;
+            flag = noConfig;
         }
     }
 
     private void resolveIfFeatures(final SchemaNode node) {
         final DeclaredStatement<?> declared = getDeclared(node);
         if (declared instanceof IfFeatureAwareDeclaredStatement) {
-            final Collection<IfFeatureStatement> ifFeature
-                    = ((IfFeatureAwareDeclaredStatement) declared).getIfFeatures();
-            this.ifFeatures.addAll(ifFeature);
+            final var ifFeature = ((IfFeatureAwareDeclaredStatement<?>) declared).getIfFeatures();
+            ifFeatures.addAll(ifFeature);
         }
     }
 
-    private DeclaredStatement<?> getDeclared(final SchemaNode node) {
+    private static DeclaredStatement<?> getDeclared(final SchemaNode node) {
         if (node instanceof AbstractDeclaredEffectiveStatement) {
-            return ((AbstractDeclaredEffectiveStatement) node).getDeclared();
+            return ((AbstractDeclaredEffectiveStatement<?, ?>) node).getDeclared();
         }
         return null;
     }
@@ -149,7 +147,7 @@ abstract class Line {
         }
     }
 
-    private boolean isBaseType(final TypeDefinition<? extends TypeDefinition<?>> type) {
+    private static boolean isBaseType(final TypeDefinition<? extends TypeDefinition<?>> type) {
         TypeDefinition<?> baseType = type.getBaseType();
         if (baseType == null) {
             return true;

--- a/src/main/java/io/lighty/yang/validator/formats/utility/SchemaHtmlEnum.java
+++ b/src/main/java/io/lighty/yang/validator/formats/utility/SchemaHtmlEnum.java
@@ -1,93 +1,32 @@
 package io.lighty.yang.validator.formats.utility;
 
+import static java.util.Objects.requireNonNull;
+
 public enum SchemaHtmlEnum {
-    CONTAINER("container") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-folder-open\"></i></span> </td>";
-        }
-    },
-    LIST("list") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-list\"></i></span> </td>";
-        }
-    },
-    LEAF("leaf") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-leaf\"></i></span> </td>";
-        }
-    },
-    LEAF_LIST("leaf-list") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fab fa-pagelines\"></i></span> </td>";
-        }
-    },
-    AUGMENT("augment") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-external-link-alt\"></i></span> </td>";
-        }
-    },
-    RPC("rpc") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-envelope\"></i></span> </td>";
-        }
-    },
-    NOTIFICATION("notification") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-bell\"></i></span> </td>";
-        }
-    },
-    CHOICE("choice") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-tasks\"></i></span> </td>";
-        }
-    },
-    CASE("case") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-check\"></i></span> </td>";
-        }
-    },
-    INPUT("input") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-share\"></i></span> </td>";
-        }
-    },
-    OUTPUT("output") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-reply\"></i></span> </td>";
-        }
-    },
-    ACTION("action") {
-        @Override
-        public String getHtmlValue() {
-            return " <span><i class=\"fas fa-play\"></i></span> </td>";
-        }
-    },
-    EMPTY("") {
-        @Override
-        public String getHtmlValue() {
-            return "";
-        }
-    };
+    CONTAINER("container",       " <span><i class=\"fas fa-folder-open\"></i></span> </td>"),
+    LIST("list",                 " <span><i class=\"fas fa-list\"></i></span> </td>"),
+    LEAF("leaf",                 " <span><i class=\"fas fa-leaf\"></i></span> </td>"),
+    LEAF_LIST("leaf-list",       " <span><i class=\"fab fa-pagelines\"></i></span> </td>"),
+    AUGMENT("augment",           " <span><i class=\"fas fa-external-link-alt\"></i></span> </td>"),
+    RPC("rpc",                   " <span><i class=\"fas fa-envelope\"></i></span> </td>"),
+    NOTIFICATION("notification", " <span><i class=\"fas fa-bell\"></i></span> </td>"),
+    CHOICE("choice",             " <span><i class=\"fas fa-tasks\"></i></span> </td>"),
+    CASE("case",                 " <span><i class=\"fas fa-check\"></i></span> </td>"),
+    INPUT("input",               " <span><i class=\"fas fa-share\"></i></span> </td>"),
+    OUTPUT("output",             " <span><i class=\"fas fa-reply\"></i></span> </td>"),
+    ACTION("action",             " <span><i class=\"fas fa-play\"></i></span> </td>"),
+    EMPTY("", "");
 
     private final String schemaName;
+    private final String htmlValue;
 
-    SchemaHtmlEnum(final String schemaName) {
-        this.schemaName = schemaName;
+    SchemaHtmlEnum(final String schemaName, final String htmlValue) {
+        this.schemaName = requireNonNull(schemaName);
+        this.htmlValue = requireNonNull(htmlValue);
     }
 
     public String getSchemaName() {
-        return this.schemaName;
+        return schemaName;
     }
 
     public static SchemaHtmlEnum getSchemaHtmlEnumByName(final String value) {
@@ -99,5 +38,7 @@ public enum SchemaHtmlEnum {
         return SchemaHtmlEnum.EMPTY;
     }
 
-    public abstract String getHtmlValue();
+    public String getHtmlValue() {
+        return htmlValue;
+    }
 }

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/ModulePrinter.java
@@ -206,7 +206,7 @@ public class ModulePrinter {
         return false;
     }
 
-    private Optional<GroupingDefinition> findMatchInGroupingDefinitions(
+    private static Optional<GroupingDefinition> findMatchInGroupingDefinitions(
             final List<GroupingDefinition> groupingDefinitions, final DataSchemaNode schemaNode) {
         Optional<GroupingDefinition> match;
         for (final GroupingDefinition grouping : groupingDefinitions) {
@@ -216,7 +216,7 @@ public class ModulePrinter {
             }
             final DataSchemaNode dataSchemaNode = dataChildByName.get();
 
-            if (!(dataSchemaNode instanceof EffectiveStatement || schemaNode instanceof EffectiveStatement)) {
+            if (!(dataSchemaNode instanceof EffectiveStatement) && !(schemaNode instanceof EffectiveStatement)) {
                 continue;
             }
             final Collection<? extends EffectiveStatement<?, ?>> effectiveStatements
@@ -234,7 +234,7 @@ public class ModulePrinter {
         return Optional.empty();
     }
 
-    private void resolveChoiceSchemaNode(final Set<SchemaTree> schemaTrees, final SchemaTree tree) {
+    private static void resolveChoiceSchemaNode(final Set<SchemaTree> schemaTrees, final SchemaTree tree) {
         boolean extendedTree = false;
         for (final SchemaTree st : schemaTrees) {
             if (st.getSchemaNode() instanceof ChoiceSchemaNode && st.getQname().equals(tree.getQname())) {
@@ -251,7 +251,7 @@ public class ModulePrinter {
         }
     }
 
-    private Optional<GroupingDefinition> getGroupingDefinitionMatch(final EffectiveStatement<?, ?> schemaNode,
+    private static Optional<GroupingDefinition> getGroupingDefinitionMatch(final EffectiveStatement<?, ?> schemaNode,
             final Collection<? extends EffectiveStatement<?, ?>> collection, final GroupingDefinition grouping) {
         boolean allSubstatementFound = true;
         for (final EffectiveStatement<?, ?> compare : schemaNode.effectiveSubstatements()) {
@@ -266,17 +266,15 @@ public class ModulePrinter {
         return Optional.empty();
     }
 
-    private boolean isSubstatementNotFound(final Collection<? extends EffectiveStatement<?, ?>> collection,
+    private static boolean isSubstatementNotFound(final Collection<? extends EffectiveStatement<?, ?>> collection,
             final EffectiveStatement<?, ?> compare) {
         for (final EffectiveStatement<?, ?> substatement : collection) {
             if (compare.getDeclared() == null) {
                 if (compare.equals(substatement)) {
                     return false;
                 }
-            } else {
-                if (compare.getDeclared().equals(substatement.getDeclared())) {
-                    return false;
-                }
+            } else if (compare.getDeclared().equals(substatement.getDeclared())) {
+                return false;
             }
         }
         return true;
@@ -297,16 +295,14 @@ public class ModulePrinter {
             if (schemaNode instanceof ContainerLike) {
                 printer.openStatement(Statement.CONTAINER, schemaNode.getQName().getLocalName());
                 printer.printConfig(schemaNode.isConfiguration());
-            } else if (schemaNode instanceof ListSchemaNode) {
-                final ListSchemaNode listSchemaNode = (ListSchemaNode) schemaNode;
+            } else if (schemaNode instanceof ListSchemaNode listSchemaNode) {
                 printer.openStatement(Statement.LIST, schemaNode.getQName().getLocalName());
                 final StringJoiner keyJoiner = new StringJoiner(" ", "key \"", "\"");
                 listSchemaNode.getKeyDefinition().stream()
                         .map(QName::getLocalName)
                         .forEach(keyJoiner::add);
                 printer.printSimple("", keyJoiner.toString());
-            } else if (schemaNode instanceof LeafSchemaNode) {
-                final LeafSchemaNode leafSchemaNode = (LeafSchemaNode) schemaNode;
+            } else if (schemaNode instanceof LeafSchemaNode leafSchemaNode) {
                 printer.openStatement(Statement.LEAF, schemaNode.getQName().getLocalName());
                 typePrinter.printType(printer, leafSchemaNode);
             } else if (schemaNode instanceof ChoiceSchemaNode) {
@@ -439,7 +435,7 @@ public class ModulePrinter {
 
     private void printImports() {
         for (final ModuleImport anImport : module.getImports()) {
-            if (this.usedImports.contains(anImport.getModuleName().getLocalName())) {
+            if (usedImports.contains(anImport.getModuleName().getLocalName())) {
                 printer.openStatement(Statement.IMPORT, anImport.getModuleName().getLocalName());
                 printer.printSimple("prefix", anImport.getPrefix());
                 printer.closeStatement();
@@ -448,7 +444,8 @@ public class ModulePrinter {
         }
     }
 
-    private boolean isStAugmentOrStParentEqualsToAugmPath(final SchemaTree st, final AugmentationSchemaNode augmSN) {
+    private static boolean isStAugmentOrStParentEqualsToAugmPath(final SchemaTree st,
+            final AugmentationSchemaNode augmSN) {
         if (st.isAugmenting()) {
             final List<QName> qnamePath = st.getAbsolutePath().getNodeIdentifiers();
             if (qnamePath.size() > 1) {

--- a/src/main/java/io/lighty/yang/validator/formats/yang/printer/TypePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/yang/printer/TypePrinter.java
@@ -48,21 +48,15 @@ class TypePrinter {
 
     void printType(final TypeDefinition<?> type) {
         final String rootName = Util.getRootType(type).getQName().getLocalName();
-        if (type instanceof EnumTypeDefinition) {
-            final EnumTypeDefinition enumTypeDefinition = (EnumTypeDefinition) type;
+        if (type instanceof EnumTypeDefinition enumTypeDefinition) {
             printEnumType(enumTypeDefinition);
-        } else if (type instanceof UnionTypeDefinition) {
-            final UnionTypeDefinition unionTypeDefinition = (UnionTypeDefinition) type;
+        } else if (type instanceof UnionTypeDefinition unionTypeDefinition) {
             printUnionType(unionTypeDefinition);
-        } else if (type instanceof DecimalTypeDefinition) {
-            final DecimalTypeDefinition decimalTypeDefinition = ((DecimalTypeDefinition) type);
+        } else if (type instanceof DecimalTypeDefinition decimalTypeDefinition) {
             printDecimalType(rootName, decimalTypeDefinition);
-        } else if (type instanceof StringTypeDefinition) {
-            final StringTypeDefinition stringType = (StringTypeDefinition) type;
+        } else if (type instanceof StringTypeDefinition stringType) {
             printStringType(rootName, stringType);
-        } else if (type instanceof RangeRestrictedTypeDefinition) {
-            final RangeRestrictedTypeDefinition<?, ?> rangeRestrictedTypeDefinition
-                    = ((RangeRestrictedTypeDefinition<?, ?>) type);
+        } else if (type instanceof RangeRestrictedTypeDefinition<?, ?> rangeRestrictedTypeDefinition) {
             printRangeRestictedType(rootName, rangeRestrictedTypeDefinition);
         } else {
             printer.printSimple("type", rootName);
@@ -124,7 +118,7 @@ class TypePrinter {
         printer.closeStatement();
     }
 
-    private boolean isRestricted(final LengthConstraint lengthConstraint) {
+    private static boolean isRestricted(final LengthConstraint lengthConstraint) {
         final Set<Range<Integer>> asRanges = lengthConstraint.getAllowedRanges().asRanges();
         if (asRanges.size() > 1) {
             return true;
@@ -133,12 +127,11 @@ class TypePrinter {
         return range.lowerEndpoint() != 0 || range.upperEndpoint() != Integer.MAX_VALUE;
     }
 
-    private String rangeToString(final RangeSet<? extends Number> rangeSet) {
+    private static String rangeToString(final RangeSet<? extends Number> rangeSet) {
         return rangeSet.asRanges().stream()
                 .map(range -> range.lowerEndpoint() + ".." + range.upperEndpoint())
                 .collect(Collectors.joining(" | "));
     }
-
 
     private void printEnum(final EnumTypeDefinition.EnumPair enumPair) {
         printer.openStatement(Statement.ENUM, enumPair.getName());

--- a/src/main/java/io/lighty/yang/validator/simplify/SchemaSelector.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/SchemaSelector.java
@@ -41,7 +41,7 @@ public class SchemaSelector {
     @SuppressWarnings("UnstableApiUsage")
     public SchemaSelector(final EffectiveModelContext effectiveModelContext) {
         this.effectiveModelContext = effectiveModelContext;
-        this.codecs = XmlCodecFactory.create(effectiveModelContext);
+        codecs = XmlCodecFactory.create(effectiveModelContext);
         tree = new SchemaTree(SchemaTree.ROOT, null,
                 false, false, null);
     }
@@ -59,11 +59,9 @@ public class SchemaSelector {
         final XMLStreamReader reader = FACTORY.createXMLStreamReader(input);
         final NormalizedNodeResult result = new NormalizedNodeResult();
         final NormalizedNodeStreamWriter streamWriter = ImmutableNormalizedNodeStreamWriter.from(result);
-        final TrackingXmlParserStream xmlParser =
-                new TrackingXmlParserStream(streamWriter, codecs, effectiveModelContext, true, st);
-        xmlParser.parse(reader);
-        xmlParser.flush();
-        xmlParser.close();
+        try (var xmlParser = new TrackingXmlParserStream(streamWriter, codecs, effectiveModelContext, true, st)) {
+            xmlParser.parse(reader);
+        }
     }
 
     public void noXml() {

--- a/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
+++ b/src/main/java/io/lighty/yang/validator/simplify/stream/TrackingXmlParserStream.java
@@ -331,7 +331,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
             final SchemaTree parentTree = schemaTree;
             final int countOfSchemaISLevels = childDataSchemaNodes.size();
             schemaTree = getSchemaTreeWithAddedChildren(schemaTree, childDataSchemaNodes, schemaIS);
-            read(in, ((CompositeNodeDataWithSchema) parent).addChild(childDataSchemaNodes, ChildReusePolicy.NOOP),
+            read(in, ((CompositeNodeDataWithSchema<?>) parent).addChild(childDataSchemaNodes, ChildReusePolicy.NOOP),
                     rootElement, schemaTree, schemaIS);
             schemaTree = parentTree;
             for (int i = 0; i < countOfSchemaISLevels; i++) {
@@ -340,7 +340,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
         }
     }
 
-    private String getXmlElementNamespace(final XMLStreamReader in, final Set<Entry<String, String>> namesakes,
+    private static String getXmlElementNamespace(final XMLStreamReader in, final Set<Entry<String, String>> namesakes,
             final String xmlElementName) {
         final String xmlElementNamespace = in.getNamespaceURI();
         if (!namesakes.add(new SimpleImmutableEntry<>(xmlElementNamespace, xmlElementName))) {
@@ -352,7 +352,7 @@ public final class TrackingXmlParserStream implements Closeable, Flushable {
         return xmlElementNamespace;
     }
 
-    private SchemaTree getSchemaTreeWithAddedChildren(SchemaTree schemaTree,
+    private static SchemaTree getSchemaTreeWithAddedChildren(SchemaTree schemaTree,
             final Deque<DataSchemaNode> childDataSchemaNodes, final SchemaInferenceStack schemaIS) {
         for (final DataSchemaNode less : childDataSchemaNodes) {
             /*

--- a/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
+++ b/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
@@ -17,7 +17,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
@@ -134,8 +133,8 @@ public final class ItUtils {
 
     public static void verifyTwoUnsortedArrays(final List<String> splitOut, final List<String> splitExp) {
         verifyLengthOfElements(splitOut, splitExp);
-        Collections.sort(splitExp);
-        Collections.sort(splitOut);
+        splitExp.sort(null);
+        splitOut.sort(null);
         assertEquals(splitOut, splitExp);
     }
 


### PR DESCRIPTION
Correct a number of warnings around:
- AutoCloseable management
- potentially-static methods
- raw types
- nullness mismatches

In touched files also perform automated cleanups:
- remove unneeded 'this.' qualifier
- use instanceof patterns where needed
- simplify expressions

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>