### PR TITLE
(16.x) Fix sonarcloud reported issues

### DIFF
--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -226,7 +226,7 @@ public class JsTree extends FormatPlugin {
             final Optional<DataSchemaNode> dataTreeChild = schemaContext.findDataTreeChild(qnamesCopy);
             if (dataTreeChild.isPresent() && dataTreeChild.get() instanceof ActionNodeContainer) {
                 final ActionNodeContainer actionSchemaNode =
-                        (ActionNodeContainer) this.schemaContext.findDataTreeChild(qnamesCopy).get();
+                        (ActionNodeContainer) dataTreeChild.get();
                 actions = actionSchemaNode.getActions();
             }
         }

--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -225,9 +225,7 @@ public class JsTree extends FormatPlugin {
             inputOutputOther = getRpcInputOutput(qnames, actions, inputOutputOther, i, qnamesCopy);
             final Optional<DataSchemaNode> dataTreeChild = schemaContext.findDataTreeChild(qnamesCopy);
             if (dataTreeChild.isPresent() && dataTreeChild.get() instanceof ActionNodeContainer) {
-                final ActionNodeContainer actionSchemaNode =
-                        (ActionNodeContainer) dataTreeChild.get();
-                actions = actionSchemaNode.getActions();
+                actions = actions = ((ActionNodeContainer) dataTreeChild.get()).getActions();
             }
         }
         return inputOutputOther;


### PR DESCRIPTION
No need to duplicately find dataTreeChild, use the value from variable instead.