### PR TITLE
Use already found dataTreeChild

### DIFF
--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -225,9 +225,7 @@ public class JsTree extends FormatPlugin {
             inputOutputOther = getRpcInputOutput(qnames, actions, inputOutputOther, i, qnamesCopy);
             final Optional<DataSchemaNode> dataTreeChild = schemaContext.findDataTreeChild(qnamesCopy);
             if (dataTreeChild.isPresent() && dataTreeChild.get() instanceof ActionNodeContainer) {
-                final ActionNodeContainer actionSchemaNode =
-                        (ActionNodeContainer) this.schemaContext.findDataTreeChild(qnamesCopy).get();
-                actions = actionSchemaNode.getActions();
+                actions = ((ActionNodeContainer) dataTreeChild.get()).getActions();
             }
         }
         return inputOutputOther;


### PR DESCRIPTION
Use already resolved dataTreeChild instead of trying to find it again.

Reported as a bug in sonarcloud.

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit b46219a97b2f5fe7d22439aa4b30e46026a97384)