### PR TITLE
Use functional style ifPresent condition

### DIFF
--- a/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
+++ b/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
@@ -633,18 +633,12 @@ public class CheckUpdateFrom {
             final PatternConstraint pattern = patterns.get(i);
             stringBuilder.append("{regex=")
                     .append(pattern.getJavaPatternString());
-            final Optional<String> errorMessage = pattern.getErrorMessage();
-            if (errorMessage.isPresent()) {
-                stringBuilder.append(",")
-                        .append("errorMessage=")
-                        .append(pattern.getErrorMessage().get());
-            }
-            final Optional<String> errorAppTag = pattern.getErrorAppTag();
-            if (errorAppTag.isPresent()) {
-                stringBuilder.append(",")
-                        .append("errorAppTag=")
-                        .append(pattern.getErrorAppTag().get());
-            }
+            pattern.getErrorMessage().ifPresent(s -> stringBuilder.append(",")
+                    .append("errorMessage=")
+                    .append(s));
+            pattern.getErrorAppTag().ifPresent(s -> stringBuilder.append(",")
+                    .append("errorAppTag=")
+                    .append(s));
             stringBuilder.append("}");
 
             if (i != patterns.size() - 1) {


### PR DESCRIPTION
Replace conditions, like if(Optional.isPresent()),that can be rewritten in the functional style, as it is shorter and easier to read.

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit e2981ec435e53719d33b89e84d2bf13edcf9142b)