### PR TITLE
Add dependency management for yangtools-artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,19 @@
         <application.attach.zip>true</application.attach.zip>
     </properties>
 
+    <!-- FIXME: Remove this when bumping to more recent Lighty.core -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.opendaylight.yangtools</groupId>
+                <artifactId>yangtools-artifacts</artifactId>
+                <version>9.0.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>net.sourceforge.argparse4j</groupId>


### PR DESCRIPTION
Make lighty-yang-validator use newer version than defined in its parent by using dependency management.

Lighty-parent uses 9.0.1 and we want to use 9.0.3

Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>