### PR TITLE
Fix format output when deviation is used

### DIFF
--- a/src/main/java/io/lighty/yang/validator/YangContextFactory.java
+++ b/src/main/java/io/lighty/yang/validator/YangContextFactory.java
@@ -19,11 +19,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import org.opendaylight.yangtools.yang.common.QName;
-import org.opendaylight.yangtools.yang.common.UnresolvedQName.Unqualified;
 import org.opendaylight.yangtools.yang.common.YangConstants;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.Module;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
 import org.opendaylight.yangtools.yang.model.repo.api.YangTextSchemaSource;
 import org.opendaylight.yangtools.yang.parser.api.YangParser;
 import org.opendaylight.yangtools.yang.parser.api.YangParserException;
@@ -37,7 +35,7 @@ final class YangContextFactory {
     private final List<File> testFiles = new ArrayList<>();
     private final List<File> libFiles = new ArrayList<>();
     private final Set<QName> supportedFeatures;
-    private final List<SourceIdentifier> sourceIdentifiers = new ArrayList<>();
+    private final List<Module> testedModules = new ArrayList<>();
 
     YangContextFactory(final List<String> yangLibDirs, final List<String> yangTestFiles,
             final Set<QName> supportedFeatures, final boolean recursiveSearch) throws IOException {
@@ -90,15 +88,15 @@ final class YangContextFactory {
         for (final Module next : effectiveModelContext.getModules()) {
             for (final String name : names) {
                 if (next.getName().equals(name)) {
-                    sourceIdentifiers.add(new SourceIdentifier(Unqualified.of(name), next.getRevision().orElse(null)));
+                    testedModules.add(next);
                 }
             }
         }
         return effectiveModelContext;
     }
 
-    List<SourceIdentifier> getTestFilesSourceIdentifiers() {
-        return sourceIdentifiers;
+    List<Module> getModulesForTesting() {
+        return testedModules;
     }
 
     private static Collection<File> getYangFiles(final String yangSourcesDirectoryPath, final boolean recursiveSearch) {

--- a/src/main/java/io/lighty/yang/validator/YangContextFactory.java
+++ b/src/main/java/io/lighty/yang/validator/YangContextFactory.java
@@ -9,11 +9,7 @@ package io.lighty.yang.validator;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -22,8 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.common.UnresolvedQName.Unqualified;
 import org.opendaylight.yangtools.yang.common.YangConstants;
@@ -38,8 +32,6 @@ import org.opendaylight.yangtools.yang.parser.impl.DefaultYangParserFactory;
 
 final class YangContextFactory {
 
-    private static final Pattern MODULE_PATTERN = Pattern.compile("module(.*?)\\{");
-    private static final Pattern WHITESPACES = Pattern.compile("\\s+");
     private static final YangParserFactory PARSER_FACTORY = new DefaultYangParserFactory();
 
     private final List<File> testFiles = new ArrayList<>();
@@ -53,15 +45,11 @@ final class YangContextFactory {
 
         final Set<String> yangLibDirsSet = new HashSet<>();
         for (final String yangTestFile : yangTestFiles) {
-            final File file;
-            if (!yangTestFile.endsWith(YangConstants.RFC6020_YANG_FILE_EXTENSION)) {
-                file = findInFiles(libFiles, yangTestFile);
-                testFiles.add(file);
-            } else {
-                file = new File(yangTestFile);
+            if (yangTestFile.endsWith(YangConstants.RFC6020_YANG_FILE_EXTENSION)) {
+                final var file = new File(yangTestFile);
+                yangLibDirsSet.add(file.getParent());
                 testFiles.add(file);
             }
-            yangLibDirsSet.add(file.getParent());
         }
         yangLibDirsSet.addAll(yangLibDirs);
         for (final String yangLibDir : yangLibDirsSet) {
@@ -113,25 +101,6 @@ final class YangContextFactory {
 
     List<SourceIdentifier> getTestFilesSourceIdentifiers() {
         return sourceIdentifiers;
-    }
-
-    private static File findInFiles(final List<File> libFiles, final String yangTestFile) throws IOException {
-        for (final File file : libFiles) {
-            if (WHITESPACES.matcher(getModelNameFromFile(file)).replaceAll("").equals(yangTestFile)) {
-                return file;
-            }
-        }
-        throw new FileNotFoundException("Model with specific module-name does not exist : " + yangTestFile);
-    }
-
-    private static String getModelNameFromFile(final File file) throws IOException {
-        final String fileAsString = readFile(file.getAbsolutePath());
-        final Matcher matcher = MODULE_PATTERN.matcher(fileAsString);
-        return matcher.find() ? matcher.group(1) : "";
-    }
-
-    private static String readFile(final String path) throws IOException {
-        return new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8);
     }
 
     private static Collection<File> getYangFiles(final String yangSourcesDirectoryPath, final boolean recursiveSearch) {

--- a/src/main/java/io/lighty/yang/validator/YangContextFactory.java
+++ b/src/main/java/io/lighty/yang/validator/YangContextFactory.java
@@ -76,15 +76,13 @@ final class YangContextFactory {
             parser.addSource(yangTextSchemaSource);
         }
         for (final File file : libFiles) {
-            if (useAllFiles) {
-                final YangTextSchemaSource yangTextSchemaSource = YangTextSchemaSource.forPath(file.toPath());
-                final String name = yangTextSchemaSource.getIdentifier().name().getLocalName();
-
-                if (!names.contains(name)) {
+            final YangTextSchemaSource yangTextSchemaSource = YangTextSchemaSource.forPath(file.toPath());
+            if (!names.contains(yangTextSchemaSource.getIdentifier().name().getLocalName())) {
+                if (useAllFiles) {
                     parser.addSource(yangTextSchemaSource);
+                } else {
+                    parser.addLibSource(YangTextSchemaSource.forPath(file.toPath()));
                 }
-            } else {
-                parser.addLibSource(YangTextSchemaSource.forPath(file.toPath()));
             }
         }
 

--- a/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
+++ b/src/main/java/io/lighty/yang/validator/checkupdatefrom/CheckUpdateFrom.java
@@ -111,13 +111,12 @@ public class CheckUpdateFrom {
 
     private final Set<CheckUpdateFromErrorRFC6020> errors = new LinkedHashSet<>();
 
-    public CheckUpdateFrom(final EffectiveModelContext newContext, final String newModule,
+    public CheckUpdateFrom(final EffectiveModelContext newContext, final Module newModule,
             final EffectiveModelContext oldContext, final String oldModule, final int rfcVersion) {
-        final String newModuleName = extractModuleName(newModule);
         final String oldModuleName = extractModuleName(oldModule);
         oldSchemaIS = SchemaInferenceStack.of(oldContext);
         newSchemaIS = SchemaInferenceStack.of(newContext);
-        this.newModule = newContext.findModules(newModuleName).iterator().next();
+        this.newModule = newModule;
         this.oldModule = oldContext.findModules(oldModuleName).iterator().next();
         is7950 = rfcVersion == 7950;
     }

--- a/src/main/java/io/lighty/yang/validator/formats/Emitter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Emitter.java
@@ -9,9 +9,8 @@ package io.lighty.yang.validator.formats;
 
 import io.lighty.yang.validator.config.Configuration;
 import io.lighty.yang.validator.simplify.SchemaTree;
-import java.util.List;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
+import org.opendaylight.yangtools.yang.model.api.Module;
 
 public interface Emitter {
 
@@ -20,11 +19,10 @@ public interface Emitter {
      *
      * @param config                 all the configuration chosen by user
      * @param context                yang schema context
-     * @param testFilesSchemaSources yang modules that are tested
+     * @param module                 yang modules that are tested
      * @param schemaTree             Tree representation of schema nodes
      */
-    void init(Configuration config, EffectiveModelContext context,
-            List<SourceIdentifier> testFilesSchemaSources, SchemaTree schemaTree);
+    void init(Configuration config, EffectiveModelContext context, Module module, SchemaTree schemaTree);
 
     /**
      * Create logic and emit output.

--- a/src/main/java/io/lighty/yang/validator/formats/Format.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Format.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
+import org.opendaylight.yangtools.yang.model.api.Module;
 
 public class Format implements Emitter, CommandLineOptions {
 
@@ -40,14 +40,13 @@ public class Format implements Emitter, CommandLineOptions {
     }
 
     @Override
-    public void init(final Configuration config, final EffectiveModelContext context,
-            final List<SourceIdentifier> testFilesSchemaSources,
+    public void init(final Configuration config, final EffectiveModelContext context, final Module module,
             final SchemaTree schemaTree) {
         final String format = config.getFormat();
         for (final FormatPlugin plugin : this.formatPlugins) {
             if (plugin.getHelp().getName().equals(format)) {
                 this.usedFormat = plugin;
-                this.usedFormat.init(context, testFilesSchemaSources, schemaTree, config);
+                this.usedFormat.init(context, module, schemaTree, config);
             }
         }
     }

--- a/src/main/java/io/lighty/yang/validator/formats/FormatPlugin.java
+++ b/src/main/java/io/lighty/yang/validator/formats/FormatPlugin.java
@@ -12,23 +12,25 @@ import io.lighty.yang.validator.config.Configuration;
 import io.lighty.yang.validator.simplify.SchemaTree;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.Optional;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
+import org.opendaylight.yangtools.yang.model.api.Module;
 
 public abstract class FormatPlugin {
 
+    static final String EMPTY_MODULE_EXCEPTION = "Provided yang module is empty. Ensure that provided path contains"
+            + " file/files with .yang extension";
+
     EffectiveModelContext schemaContext;
-    List<SourceIdentifier> sources;
+    Module testedModule;
     SchemaTree schemaTree;
     Path output;
     Configuration configuration;
 
-    void init(final EffectiveModelContext context, final List<SourceIdentifier> testFilesSchemaSources,
+    void init(final EffectiveModelContext context, final Module module,
             final SchemaTree tree, final Configuration config) {
         this.schemaContext = context;
-        this.sources = testFilesSchemaSources;
+        this.testedModule = module;
         this.schemaTree = tree;
         this.configuration = config;
         final String out = config.getOutput();

--- a/src/main/java/io/lighty/yang/validator/formats/FormatPlugin.java
+++ b/src/main/java/io/lighty/yang/validator/formats/FormatPlugin.java
@@ -7,6 +7,7 @@
  */
 package io.lighty.yang.validator.formats;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.lighty.yang.validator.GroupArguments;
 import io.lighty.yang.validator.config.Configuration;
 import io.lighty.yang.validator.simplify.SchemaTree;
@@ -18,8 +19,9 @@ import org.opendaylight.yangtools.yang.model.api.Module;
 
 public abstract class FormatPlugin {
 
-    static final String EMPTY_MODULE_EXCEPTION = "Provided yang module is empty. Ensure that provided path contains"
-            + " file/files with .yang extension";
+    @VisibleForTesting
+    public static final String EMPTY_MODULE_EXCEPTION = "Provided yang module is empty. Ensure that provided path"
+            + " contains file/files with .yang extension";
 
     EffectiveModelContext schemaContext;
     Module testedModule;

--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -10,7 +10,6 @@ package io.lighty.yang.validator.formats;
 import com.google.common.io.Resources;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lighty.yang.validator.GroupArguments;
-import io.lighty.yang.validator.exceptions.NotFoundException;
 import io.lighty.yang.validator.formats.utility.LyvNodeData;
 import io.lighty.yang.validator.formats.utility.LyvStack;
 import java.io.IOException;
@@ -39,7 +38,6 @@ import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.NotificationDefinition;
 import org.opendaylight.yangtools.yang.model.api.RpcDefinition;
 import org.opendaylight.yangtools.yang.model.api.SchemaNode;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,33 +54,33 @@ public class JsTree extends FormatPlugin {
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
-        namespacePrefix = new HashMap<>();
-        for (final SourceIdentifier source : sources) {
-            final Module module = schemaContext.findModule(source.name().getLocalName(), source.revision())
-                    .orElseThrow(() -> new NotFoundException("Module", source.name().getLocalName()));
+        if (testedModule != null) {
+            namespacePrefix = new HashMap<>();
             final SingletonListInitializer singletonListInitializer = new SingletonListInitializer(1);
 
             // Nodes
-            printLines(getChildNodesLines(singletonListInitializer, module));
+            printLines(getChildNodesLines(singletonListInitializer, testedModule));
 
             // Augmentations
-            for (final AugmentationSchemaNode augNode : module.getAugmentations()) {
+            for (final AugmentationSchemaNode augNode : testedModule.getAugmentations()) {
                 printLines(getAugmentationNodesLines(singletonListInitializer.getSingletonListWithIncreasedValue(),
                         augNode));
             }
 
             // Rpcs
-            printLines(getRpcsLines(singletonListInitializer, module));
+            printLines(getRpcsLines(singletonListInitializer, testedModule));
 
             // Notifications
-            printLines(getNotificationsLines(singletonListInitializer, module));
-        }
+            printLines(getNotificationsLines(singletonListInitializer, testedModule));
 
-        LOG.info("</table>");
-        LOG.info("</div>");
-        LOG.info("{}", loadJS());
-        LOG.info("</body>");
-        LOG.info("</html>");
+            LOG.info("</table>");
+            LOG.info("</div>");
+            LOG.info("{}", loadJS());
+            LOG.info("</body>");
+            LOG.info("</html>");
+        } else {
+            LOG.error(EMPTY_MODULE_EXCEPTION);
+        }
     }
 
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",

--- a/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
@@ -46,7 +46,6 @@ import org.opendaylight.yangtools.yang.model.api.TypeDefinition;
 import org.opendaylight.yangtools.yang.model.api.TypedDataSchemaNode;
 import org.opendaylight.yangtools.yang.model.api.stmt.SchemaNodeIdentifier;
 import org.opendaylight.yangtools.yang.model.api.type.IdentityrefTypeDefinition;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,31 +87,28 @@ public class JsonTree extends FormatPlugin {
     private static final String COLON = ":";
 
     @Override
-    void init(final EffectiveModelContext context, final List<SourceIdentifier> testFilesSchemaSources,
-            final SchemaTree schemaTree, final Configuration config) {
-        super.init(context, testFilesSchemaSources, schemaTree, config);
+    void init(final EffectiveModelContext context, final Module module, final SchemaTree schemaTree,
+            final Configuration config) {
+        super.init(context, module, schemaTree, config);
     }
 
     @Override
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
-        final LyvStack stack = new LyvStack();
-
-        for (final SourceIdentifier source : sources) {
-            final Module module = schemaContext.findModule(source.name().getLocalName(), source.revision())
-                    .orElseThrow(() -> new NotFoundException(MODULE_STRING, source.name().getLocalName()));
-            final JSONObject moduleMetadata = resolveModuleMetadata(module);
+        if (testedModule != null) {
+            final LyvStack stack = new LyvStack();
+            final JSONObject moduleMetadata = resolveModuleMetadata(testedModule);
             final JSONObject jsonTree = new JSONObject();
 
-            appendChildNodesToJsonTree(module, jsonTree, stack);
+            appendChildNodesToJsonTree(testedModule, jsonTree, stack);
             stack.clear();
-            appendNotificationsToJsonTree(module, jsonTree, stack);
+            appendNotificationsToJsonTree(testedModule, jsonTree, stack);
             stack.clear();
-            appendRpcsToJsonTree(module, jsonTree, stack);
+            appendRpcsToJsonTree(testedModule, jsonTree, stack);
             stack.clear();
 
-            for (final AugmentationSchemaNode augmentation : module.getAugmentations()) {
+            for (final AugmentationSchemaNode augmentation : testedModule.getAugmentations()) {
                 stack.enter(augmentation.getTargetPath());
                 final JSONObject augmentationJson = new JSONObject();
                 final boolean isConfig = isAugmentConfig(augmentation);
@@ -133,13 +129,15 @@ public class JsonTree extends FormatPlugin {
                 }
 
                 appendActionsToAugmentationJson(augmentation, augmentationJson, stack);
-                appendNotificationsToAugmentationJson(module, augmentationJson, stack);
+                appendNotificationsToAugmentationJson(testedModule, augmentationJson, stack);
                 jsonTree.append(AUGMENTS, augmentationJson);
                 stack.clear();
             }
             jsonTree.put(MODULE, moduleMetadata);
             final String jsonTreeText = jsonTree.toString(4);
             LOG.info("{}", jsonTreeText);
+        } else {
+            LOG.error("{}", EMPTY_MODULE_EXCEPTION);
         }
     }
 

--- a/src/main/java/io/lighty/yang/validator/formats/NameRevision.java
+++ b/src/main/java/io/lighty/yang/validator/formats/NameRevision.java
@@ -9,11 +9,8 @@ package io.lighty.yang.validator.formats;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lighty.yang.validator.GroupArguments;
-import io.lighty.yang.validator.exceptions.NotFoundException;
 import java.util.Optional;
 import org.opendaylight.yangtools.yang.common.Revision;
-import org.opendaylight.yangtools.yang.model.api.Module;
-import org.opendaylight.yangtools.yang.model.repo.api.SourceIdentifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,15 +26,15 @@ public class NameRevision extends FormatPlugin {
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
     public void emitFormat() {
-        for (final SourceIdentifier source : this.sources) {
-            final Module module = this.schemaContext.findModule(source.name().getLocalName(), source.revision())
-                    .orElseThrow(() -> new NotFoundException("Module", source.name().getLocalName()));
-            final Optional<Revision> revision = module.getRevision();
-            String moduleName = module.getName();
+        if (testedModule != null) {
+            final Optional<Revision> revision = testedModule.getRevision();
+            String moduleName = testedModule.getName();
             if (revision.isPresent()) {
                 moduleName += ET + revision.get();
             }
             LOG.info("{}", moduleName);
+        } else {
+            LOG.error("{}", EMPTY_MODULE_EXCEPTION);
         }
     }
 

--- a/src/test/java/io/lighty/yang/validator/FormatTest.java
+++ b/src/test/java/io/lighty/yang/validator/FormatTest.java
@@ -8,6 +8,7 @@
 package io.lighty.yang.validator;
 
 import static io.lighty.yang.validator.Main.runLYV;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.config.Configuration;
@@ -65,7 +66,11 @@ public abstract class FormatTest implements Cleanable {
         //only root tree
         setFormat();
         final String module = Paths.get(this.yangPath).resolve("ietf-interfaces@2018-02-20.yang").toString();
-        runLYV(ImmutableList.of(module), this.builder.build(), this.formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runInterfacesTest();
     }
 
@@ -74,7 +79,11 @@ public abstract class FormatTest implements Cleanable {
         //contains augmentations
         setFormat();
         final String module = Paths.get(this.yangPath).resolve("ietf-ip@2018-02-22.yang").toString();
-        runLYV(ImmutableList.of(module), this.builder.build(), this.formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runIpTest();
     }
 
@@ -84,7 +93,11 @@ public abstract class FormatTest implements Cleanable {
         setFormat();
         final String module =
                 Paths.get(this.yangPath).resolve("ietf-connection-oriented-oam@2019-04-16.yang").toString();
-        runLYV(ImmutableList.of(module), this.builder.build(), this.formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runConnectionOrentedOamTest();
     }
 
@@ -93,7 +106,11 @@ public abstract class FormatTest implements Cleanable {
         //contains actions
         setFormat();
         final String module = Paths.get(this.yangPath).resolve("ietf-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), this.builder.build(), this.formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runRoutingTest();
     }
 
@@ -104,7 +121,11 @@ public abstract class FormatTest implements Cleanable {
          */
         setFormat();
         final String module = Paths.get(this.yangPath).resolve("test_model@2020-12-03.yang").toString();
-        runLYV(ImmutableList.of(module), this.builder.build(), this.formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runCustomModuleTest();
     }
 

--- a/src/test/java/io/lighty/yang/validator/IntegrationTest.java
+++ b/src/test/java/io/lighty/yang/validator/IntegrationTest.java
@@ -7,9 +7,12 @@
  */
 package io.lighty.yang.validator;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import io.lighty.yang.validator.formats.FormatPlugin;
 import io.lighty.yang.validator.utils.ItUtils;
 import java.io.IOException;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -33,23 +36,22 @@ public class IntegrationTest implements Cleanable {
     public void notFoundImportFormatParseAllTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvParseAllWithFileOutput("integration/yang", "tree");
 
-        Assert.assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
-        Assert.assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
+        assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
+        assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
     }
 
     @Test
     public void wrongYangTreeFormatParseAllTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvParseAllWithFileOutput("integration/xml/", "tree");
 
-        Assert.assertTrue(lyvOutput.contains("Failed to create YangContextFactory"));
-        Assert.assertTrue(lyvOutput.contains("Model with specific module-name does not exist"));
+        assertTrue(lyvOutput.contains(FormatPlugin.EMPTY_MODULE_EXCEPTION));
     }
 
     @Test
     public void treeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/test_model@2020-12-03.yang", "tree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestTree.txt");
-        Assert.assertEquals(lyvOutput, expectedOutput);
+        assertEquals(lyvOutput, expectedOutput);
     }
 
     @Test
@@ -57,15 +59,15 @@ public class IntegrationTest implements Cleanable {
         final String lyvOutput = ItUtils.startRecursivelyLyvWithFileOutput("yang",
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "tree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestTreeRecursive.txt");
-        Assert.assertEquals(lyvOutput, expectedOutput);
+        assertEquals(lyvOutput, expectedOutput);
     }
 
     @Test
     public void notFoundImportTreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput(
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "tree");
-        Assert.assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
-        Assert.assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
+        assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
+        assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
     }
 
     @Test
@@ -81,45 +83,45 @@ public class IntegrationTest implements Cleanable {
     public void notFoundImportDependFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput(
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "depend");
-        Assert.assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
-        Assert.assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
+        assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
+        assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
     }
 
     @Test
     public void jsonTreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/test_model@2020-12-03.yang", "json-tree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestJsonTree.json");
-        Assert.assertEquals(lyvOutput, expectedOutput);
+        assertEquals(lyvOutput, expectedOutput);
     }
 
     @Test
     public void notFoundImportJsonTreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput(
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "json-tree");
-        Assert.assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
-        Assert.assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
+        assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
+        assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
     }
 
     @Test
     public void jstreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/test_model@2020-12-03.yang", "jstree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestJsTree.html");
-        Assert.assertEquals(lyvOutput.replaceAll(" \n", "\n"), expectedOutput);
+        assertEquals(lyvOutput.replaceAll(" \n", "\n"), expectedOutput);
     }
 
     @Test
     public void notFoundImportJstreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput(
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "jstree");
-        Assert.assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
-        Assert.assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
+        assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
+        assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
     }
 
     @Test
     public void yangFormatTest() throws IOException {
         final String errorLog = ItUtils.startLyvWithFileOutput("integration/xml", "yang",
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "yang");
-        Assert.assertTrue(errorLog.isEmpty());
+        assertTrue(errorLog.isEmpty());
         final String lyvOutput = ItUtils.loadLyvOutput("/out/ietf-interfaces-modified@2018-02-20.yang");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestYang.txt");
         ItUtils.compareSimplifyYangOutput(lyvOutput, expectedOutput);
@@ -129,7 +131,7 @@ public class IntegrationTest implements Cleanable {
     public void notFoundImportYangFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("integration/xml", "integration/yang",
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "yang");
-        Assert.assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
-        Assert.assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
+        assertTrue(lyvOutput.contains("Failed to parse YANG from source SourceSpecificContext"));
+        assertTrue(lyvOutput.contains("Imported module [ietf-yang-types] was not found"));
     }
 }

--- a/src/test/java/io/lighty/yang/validator/MainTest.java
+++ b/src/test/java/io/lighty/yang/validator/MainTest.java
@@ -36,6 +36,7 @@ import org.opendaylight.yangtools.yang.data.codec.xml.XmlParserStream;
 import org.opendaylight.yangtools.yang.data.impl.schema.ImmutableNormalizedNodeStreamWriter;
 import org.opendaylight.yangtools.yang.data.impl.schema.NormalizedNodeResult;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
+import org.opendaylight.yangtools.yang.model.api.Module;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
@@ -71,8 +72,10 @@ public class MainTest implements Cleanable {
                 .setFormat("yang")
                 .setOutput(outPath)
                 .build();
-        format.init(config, effectiveModelContext, contextFactory.getTestFilesSourceIdentifiers(), schemaTree);
-        format.emit();
+        for (final Module module : effectiveModelContext.getModules()) {
+            format.init(config, effectiveModelContext, module, schemaTree);
+            format.emit();
+        }
         contextFactory =
                 new YangContextFactory(ImmutableList.of(outPath), ImmutableList.of(), Collections.emptySet(), false);
         effectiveModelContext = contextFactory.createContext(true);

--- a/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
+++ b/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
@@ -8,6 +8,7 @@
 package io.lighty.yang.validator;
 
 import static io.lighty.yang.validator.Main.runLYV;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.config.Configuration;
@@ -24,7 +25,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -71,24 +71,32 @@ public class TreeSimplifiedTest implements Cleanable {
     public void runTreeSimplifiedTest() throws Exception {
         prepare("tree", new Tree());
         final String module = Paths.get(yangPath).resolve("ietf-interfaces@2018-02-20.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(
             outLog.resolveSibling("compare").resolve("interfacesSimplified.tree"));
-        Assert.assertEquals(fileCreated, compareWith);
+        assertEquals(fileCreated, compareWith);
     }
 
     @Test
     public void runYangSimplifiedTest() throws Exception {
         prepare("yang", new MultiModulePrinter());
         final String module = Paths.get(yangPath).resolve("ietf-interfaces@2018-02-20.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         final Path outLog = Paths.get(outPath).resolve("ietf-interfaces@2018-02-20.yang");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(
             outLog.resolveSibling("compare").resolve("interfaces-simplified.yang"));
-        Assert.assertEquals(fileCreated, compareWith);
+        assertEquals(fileCreated, compareWith);
     }
 
     private void prepare(final String format, final FormatPlugin plugin) {

--- a/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
+++ b/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
@@ -7,9 +7,11 @@
  */
 package io.lighty.yang.validator.check.update.from;
 
+import static io.lighty.yang.validator.Main.getLyvContext;
 import static io.lighty.yang.validator.Main.runLYV;
 import static org.testng.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.Cleanable;
 import io.lighty.yang.validator.Main;
 import io.lighty.yang.validator.config.Configuration;
@@ -105,7 +107,10 @@ public class RFC6020Test implements Cleanable {
                 .setYangModules(Collections.singletonList(newFile))
                 .build();
 
-        runLYV(config.getYang(), config, null);
+        final var lyvContext = getLyvContext(ImmutableList.of(Paths.get(newFile).toString()), config);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), config, null, lyvContext.context());
 
         final Path outLog = Paths.get(outPath).resolve(OUT);
         final String fileCreated = Files.readString(outLog);

--- a/src/test/java/io/lighty/yang/validator/formats/AnalyzerTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/AnalyzerTest.java
@@ -8,6 +8,7 @@
 package io.lighty.yang.validator.formats;
 
 import static io.lighty.yang.validator.Main.runLYV;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.Cleanable;
@@ -74,7 +75,11 @@ public class AnalyzerTest implements Cleanable {
     @Test
     public void analyzeTest() throws Exception {
         final String module = Paths.get(yangPath).resolve("ietf-netconf-common@2013-10-21.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertTrue(modules.isEmpty());
+        runLYV(null, configuration, formatter, lyvContext.context());
         runAnalyzeTest("ietf-netconf-common-analyzed");
     }
 

--- a/src/test/java/io/lighty/yang/validator/formats/DependsTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/DependsTest.java
@@ -7,7 +7,9 @@
  */
 package io.lighty.yang.validator.formats;
 
+import static io.lighty.yang.validator.Main.getLyvContext;
 import static io.lighty.yang.validator.Main.runLYV;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.FormatTest;
@@ -18,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class DependsTest extends FormatTest {
@@ -39,7 +40,11 @@ public class DependsTest extends FormatTest {
         builder.setDependConfiguration(false, false, true,
                 new HashSet<>());
         final String module = Paths.get(yangPath).resolve("ietf-ipv6-unicast-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runDependendsTest("ietf-ipv6-router-advertisements_submodule-dependencies");
     }
 
@@ -49,7 +54,11 @@ public class DependsTest extends FormatTest {
         builder.setDependConfiguration(false, true, false,
                 new HashSet<>());
         final String module = Paths.get(yangPath).resolve("ietf-ipv6-unicast-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runDependendsTest("ietf-ipv6-router-advertisements_import-dependencies");
     }
 
@@ -59,7 +68,11 @@ public class DependsTest extends FormatTest {
         builder.setDependConfiguration(true, false, false,
                 new HashSet<>());
         final String module = Paths.get(yangPath).resolve("ietf-ipv6-unicast-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runDependendsTest("ietf-ipv6-router-advertisements_non-recursive-dependencies");
     }
 
@@ -69,7 +82,11 @@ public class DependsTest extends FormatTest {
         builder.setDependConfiguration(true, false, true,
                 new HashSet<>());
         final String module = Paths.get(yangPath).resolve("ietf-ipv6-unicast-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runDependendsTest("ietf-ipv6-router-advertisements_non-recursive-only-submodules-dependencies");
     }
 
@@ -79,7 +96,11 @@ public class DependsTest extends FormatTest {
         builder.setDependConfiguration(true, true, false,
                 new HashSet<>());
         final String module = Paths.get(yangPath).resolve("ietf-ipv6-unicast-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runDependendsTest("ietf-ipv6-router-advertisements_non-recursive-only-imports-dependencies");
     }
 
@@ -89,7 +110,11 @@ public class DependsTest extends FormatTest {
         builder.setDependConfiguration(false, false, false,
                 new HashSet<>(Collections.singleton("ietf-ipv6-router-advertisements")));
         final String module = Paths.get(yangPath).resolve("ietf-ipv6-unicast-routing@2018-03-13.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runDependendsTest("ietf-ipv6-router-advertisements_exclude-module-dependencies");
     }
 
@@ -122,7 +147,7 @@ public class DependsTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        Assert.assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/JsTreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/JsTreeTest.java
@@ -7,7 +7,9 @@
  */
 package io.lighty.yang.validator.formats;
 
+import static io.lighty.yang.validator.Main.getLyvContext;
 import static io.lighty.yang.validator.Main.runLYV;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.FormatTest;
@@ -16,7 +18,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class JsTreeTest extends FormatTest {
@@ -34,7 +35,11 @@ public class JsTreeTest extends FormatTest {
         //testing for undeclared choice-case statement (no case inside of choice)
         setFormat();
         final String module = Paths.get(yangPath).resolve("undeclared.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runJsTreeTest("undeclared.html");
     }
 
@@ -67,7 +72,7 @@ public class JsTreeTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        Assert.assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/TreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/TreeTest.java
@@ -8,14 +8,15 @@
 package io.lighty.yang.validator.formats;
 
 import static io.lighty.yang.validator.Main.runLYV;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.FormatTest;
+import io.lighty.yang.validator.Main;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -36,7 +37,11 @@ public class TreeTest extends FormatTest {
         setFormat();
         builder.setTreeConfiguration(0, 0, false, false, true);
         final String module = Paths.get(yangPath).resolve("ietf-ip@2018-02-22.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runTreeTest("ip-prefix-main-module.tree");
     }
 
@@ -45,7 +50,11 @@ public class TreeTest extends FormatTest {
         setFormat();
         builder.setTreeConfiguration(0, 0, false, true, false);
         final String module = Paths.get(yangPath).resolve("ietf-interfaces@2018-02-20.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runTreeTest("interfaces-prefix-module.tree");
     }
 
@@ -54,7 +63,11 @@ public class TreeTest extends FormatTest {
         setFormat();
         builder.setTreeConfiguration(0, 20, false, false, false);
         final String module = Paths.get(yangPath).resolve("ietf-interfaces@2018-02-20.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runTreeTest("interfaces-line-length.tree");
     }
 
@@ -62,7 +75,7 @@ public class TreeTest extends FormatTest {
     public void treeHelpTest() throws Exception {
         setFormat();
         builder.setTreeConfiguration(0, 0, true, false, false);
-        runLYV(Collections.emptyList(), builder.build(), formatter);
+        runLYV(null, builder.build(), formatter, null);
         runTreeTest("tree-help");
     }
 
@@ -71,7 +84,11 @@ public class TreeTest extends FormatTest {
         setFormat();
         builder.setTreeConfiguration(3, 0, false, false, false);
         final String module = Paths.get(yangPath).resolve("ietf-interfaces@2018-02-20.yang").toString();
-        runLYV(ImmutableList.of(module), builder.build(), formatter);
+        final var configuration = builder.build();
+        final var lyvContext = Main.getLyvContext(ImmutableList.of(module), configuration);
+        final var modules = lyvContext.testedModules();
+        assertEquals(modules.size(), 1);
+        runLYV(modules.iterator().next(), configuration, formatter, lyvContext.context());
         runTreeTest("interfaces-limited-depth.tree");
     }
 

--- a/src/test/resources/out/compare/module-deviation.tree
+++ b/src/test/resources/out/compare/module-deviation.tree
@@ -1,0 +1,7 @@
+module: deviation
+module: model
+  +--rw data-container
+     +--rw list-data* [name]
+        +--rw name       string
+augment /data-container/list-data:
+  +--rw month?       string

--- a/src/test/resources/yang/deviation/deviation.yang
+++ b/src/test/resources/yang/deviation/deviation.yang
@@ -1,0 +1,16 @@
+module deviation {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:deviation";
+  prefix dev;
+
+  import model {prefix mo;}
+
+    deviation /mo:data-container/mo:list-data/mo:year {
+        description "not-supported.";
+        deviate not-supported;
+    }
+    deviation /mo:data-container/mo:list-data/mo:month {
+        description "not-supported.";
+        deviate not-supported;
+    }
+}

--- a/src/test/resources/yang/deviation/model.yang
+++ b/src/test/resources/yang/deviation/model.yang
@@ -1,0 +1,23 @@
+module model {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:mode";
+  prefix mo;
+
+  container data-container {
+      list list-data {
+        key name;
+        leaf name {
+          type string;
+        }
+        leaf year {
+          type int64;
+        }
+      }
+  }
+
+  augment /mo:data-container/mo:list-data {
+    leaf month {
+      type string;
+    }
+  }
+}


### PR DESCRIPTION
Create EffectiveModelContext once and use it for every provided yang module instead of creating EffectiveModelContext for each file.

Creating multiple times SchemaContext takes resources, and it is not required. Moreover, it causes issue with showing nodes deleted or updated by deviation from another model.

ID: 119