### PR TITLE
Fix validation functionality

### DIFF
--- a/src/main/java/io/lighty/yang/validator/Main.java
+++ b/src/main/java/io/lighty/yang/validator/Main.java
@@ -143,7 +143,11 @@ public final class Main {
         final var yangFiles = new ArrayList<String>();
         yangFiles.addAll(moduleNameValues);
         yangFiles.addAll(config.getYang());
-        runLywForeachYangFile(yangFiles, config, format);
+        if (config.getFormat() != null) {
+            runLywForeachYangFile(yangFiles, config, format);
+        } else {
+            generateHtmlAnalyzeOutput(yangFiles, config);
+        }
     }
 
     private static void runLyvForProvidedFolder(final Configuration config, final Format format)
@@ -163,7 +167,9 @@ public final class Main {
         }
         //FIXME: This method should be called only for model validation not for all formats.
         generateHtmlAnalyzeOutput(yangFiles, config);
-        runLywForeachYangFile(yangFiles, config, format);
+        if (config.getFormat() != null) {
+            runLywForeachYangFile(yangFiles, config, format);
+        }
     }
 
     private static void runLywForeachYangFile(final List<String> yangFiles, final Configuration config,

--- a/src/test/java/io/lighty/yang/validator/IntegrationTest.java
+++ b/src/test/java/io/lighty/yang/validator/IntegrationTest.java
@@ -9,6 +9,7 @@ package io.lighty.yang.validator;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 
 import io.lighty.yang.validator.formats.FormatPlugin;
 import io.lighty.yang.validator.utils.ItUtils;
@@ -30,6 +31,24 @@ public class IntegrationTest implements Cleanable {
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestTreeParseAll.txt");
 
         ItUtils.compareModulesAndAugmentData(outputWithoutGenInfo, expectedOutput);
+    }
+
+    @Test
+    public void noFormatParseAllValidationTest() throws Exception {
+        final var lyvOutput = ItUtils.startLyvParseAllWithFileOutput("integration/yang/parse/all");
+        assertFalse(lyvOutput.trim().isEmpty());
+        final var outputWithoutGenInfo = ItUtils.removeHtmlGeneratedInfo(lyvOutput);
+        assertTrue(outputWithoutGenInfo.trim().isEmpty());
+    }
+
+    @Test
+    public void noFormatValidationTest() throws Exception {
+        final var outPath = ItUtils.class.getResource(ItUtils.OUTPUT_FOLDER).getFile();
+        final var args = new String[]{"-o", outPath, "yang/deviation/model.yang"};
+        final var lyvOutput = ItUtils.startLyvWithFileOutput(args);
+        assertFalse(lyvOutput.trim().isEmpty());
+        final var outputWithoutGenInfo = ItUtils.removeHtmlGeneratedInfo(lyvOutput);
+        assertTrue(outputWithoutGenInfo.trim().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
+++ b/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
@@ -22,8 +22,8 @@ import java.util.stream.Collectors;
 
 public final class ItUtils {
 
-    private static final String OUTPUT_FOLDER = "/out";
-    private static final String OUTPUT_LOG = "/out/out.log";
+    public static final String OUTPUT_FOLDER = "/out";
+    public static final String OUTPUT_LOG = "/out/out.log";
 
     private ItUtils() {
         throw new UnsupportedOperationException("Util class");
@@ -74,6 +74,14 @@ public final class ItUtils {
         final InputStream out = ItUtils.class.getResourceAsStream(path);
         assertNotNull(out);
         return new String(out.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    public static String startLyvParseAllWithFileOutput(final String modelFolder) throws Exception {
+        final var resource = ItUtils.class.getClassLoader().getResource(modelFolder);
+        assertNotNull(resource);
+        final var outPath = ItUtils.class.getResource(OUTPUT_FOLDER).getFile();
+        final var args = new String[]{"-o", outPath, "-a", resource.getPath()};
+        return startLyvWithFileOutput(args);
     }
 
     public static String startLyvParseAllWithFileOutput(final String modelFolder, final String format)


### PR DESCRIPTION
Add validation functionality as it was before. If condition for config.getFormat() was moved in wrong place in: commit f7072b11d52a577e563b7764fd64214457443e4c
"Create EffectiveModelContext once for all files"

And then it was removed by:
commit a8719ef884cd548077c02ff69195ab0432d4db71
"Move checkUpdateForm to separate method"