### PR TITLE
Bump lighty.io core to 16.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>16.2.0</version>
+        <version>16.3.0</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>
@@ -27,18 +27,6 @@
         <application.main.class>io.lighty.yang.validator.Main</application.main.class>
         <application.attach.zip>true</application.attach.zip>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.opendaylight.yangtools</groupId>
-                <artifactId>yangtools-artifacts</artifactId>
-                <version>8.0.9</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Bump lighty.io core to 16.3.0 to maintain compatibility with OpenDaylight Sulfur SR3 and get useful fixes.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>