### PR TITLE
Fix JsonTree issue for multiple yang files

### DIFF
--- a/src/main/java/io/lighty/yang/validator/Main.java
+++ b/src/main/java/io/lighty/yang/validator/Main.java
@@ -175,15 +175,16 @@ public final class Main {
     private static void runLywForeachYangFile(final List<String> yangFiles, final Configuration config,
             final Format format) throws LyvApplicationException {
         final var lyvContext = LyvEffectiveModelContextFactory.create(yangFiles, config);
+        format.init(config, lyvContext.context(), lyvContext.schemaTree());
         if (lyvContext.testedModules().isEmpty()) {
             // Analyse format require only EffectiveModelContext
-            format.init(config, lyvContext.context(), null, lyvContext.schemaTree());
-            format.emit();
+            format.emit(null);
         }
+
         for (final Module module : lyvContext.testedModules()) {
-            format.init(config, lyvContext.context(), module, lyvContext.schemaTree());
-            format.emit();
+            format.emit(module);
         }
+        format.close();
     }
 
     private static void generateHtmlAnalyzeOutput(final List<String> yangFiles, final Configuration config)

--- a/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Analyzer.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import org.opendaylight.yangtools.yang.model.api.Module;
 import org.opendaylight.yangtools.yang.model.api.ModuleLike;
 import org.opendaylight.yangtools.yang.model.api.meta.DeclaredStatement;
 import org.opendaylight.yangtools.yang.model.api.meta.EffectiveStatement;
@@ -30,7 +31,7 @@ public class Analyzer extends FormatPlugin {
     private final Map<String, Integer> counter = new HashMap<>();
 
     @Override
-    void emitFormat() {
+    void emitFormat(final Module module) {
         final Set<DeclaredStatement<?>> statements = getRecursivelyDeclaredStatements(modelContext.getModules());
         for (final DeclaredStatement<?> declaredStatement : statements) {
             analyzeSubstatement(declaredStatement);

--- a/src/main/java/io/lighty/yang/validator/formats/Depends.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Depends.java
@@ -42,20 +42,20 @@ public class Depends extends FormatPlugin {
     @Override
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
-    public void emitFormat() {
-        if (testedModule != null) {
+    public void emitFormat(final Module module) {
+        if (module != null) {
             final DependConfiguration dependConfiguration = configuration.getDependConfiguration();
             final StringBuilder dependantsBuilder = new StringBuilder(MODULE);
-            dependantsBuilder.append(testedModule.getName())
+            dependantsBuilder.append(module.getName())
                     .append(AT);
-            testedModule.getRevision().ifPresent(dependantsBuilder::append);
+            module.getRevision().ifPresent(dependantsBuilder::append);
 
             dependantsBuilder.append(DEPENDS_TEXT);
             if (!dependConfiguration.isModuleImportsOnly()) {
-                resolveSubmodules(testedModule, dependConfiguration);
+                resolveSubmodules(module, dependConfiguration);
             }
             if (!dependConfiguration.isModuleIncludesOnly()) {
-                resolveImports(testedModule, dependConfiguration);
+                resolveImports(module, dependConfiguration);
             }
             for (final String name : modules) {
                 dependantsBuilder.append(name)

--- a/src/main/java/io/lighty/yang/validator/formats/Emitter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Emitter.java
@@ -19,13 +19,19 @@ public interface Emitter {
      *
      * @param config                 all the configuration chosen by user
      * @param context                yang schema context
-     * @param module                 yang modules that are tested
      * @param schemaTree             Tree representation of schema nodes
      */
-    void init(Configuration config, EffectiveModelContext context, Module module, SchemaTree schemaTree);
+    void init(Configuration config, EffectiveModelContext context, SchemaTree schemaTree);
 
     /**
      * Create logic and emit output.
+     *
+     * @param module                 module to emit
      */
-    void emit();
+    void emit(Module module);
+
+    /**
+     * Close after printing out the module.
+     */
+    void close();
 }

--- a/src/main/java/io/lighty/yang/validator/formats/Format.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Format.java
@@ -40,18 +40,23 @@ public class Format implements Emitter, CommandLineOptions {
     }
 
     @Override
-    public void init(final Configuration config, final EffectiveModelContext context, final Module module,
-            final SchemaTree schemaTree) {
+    public void init(final Configuration config, final EffectiveModelContext context, final SchemaTree schemaTree) {
         final String format = config.getFormat();
         for (final FormatPlugin plugin : this.formatPlugins) {
             if (plugin.getHelp().getName().equals(format)) {
                 this.usedFormat = plugin;
-                this.usedFormat.init(context, module, schemaTree, config);
+                this.usedFormat.init(context, schemaTree, config);
             }
         }
     }
 
-    public void emit() {
-        this.usedFormat.emitFormat();
+    @Override
+    public void emit(final Module module) {
+        this.usedFormat.emitFormat(module);
+    }
+
+    @Override
+    public void close() {
+        this.usedFormat.close();
     }
 }

--- a/src/main/java/io/lighty/yang/validator/formats/FormatPlugin.java
+++ b/src/main/java/io/lighty/yang/validator/formats/FormatPlugin.java
@@ -24,15 +24,12 @@ public abstract class FormatPlugin {
             + " contains file/files with .yang extension";
 
     EffectiveModelContext modelContext;
-    Module testedModule;
     SchemaTree schemaTree;
     Path output;
     Configuration configuration;
 
-    void init(final EffectiveModelContext context, final Module module,
-            final SchemaTree tree, final Configuration config) {
+    void init(final EffectiveModelContext context, final SchemaTree tree, final Configuration config) {
         this.modelContext = context;
-        this.testedModule = module;
         this.schemaTree = tree;
         this.configuration = config;
         final String out = config.getOutput();
@@ -46,7 +43,14 @@ public abstract class FormatPlugin {
     /**
      * Logic of the plugin. Use logger to print
      */
-    abstract void emitFormat();
+    abstract void emitFormat(Module module);
+
+    /**
+     * Close after printing out the module.
+     */
+    protected void close() {
+        // no-op by default
+    }
 
     /**
      * This serves to generate help about current plugin, in case that user will use --help option with `lyv` command.

--- a/src/main/java/io/lighty/yang/validator/formats/JsTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsTree.java
@@ -50,28 +50,28 @@ public class JsTree extends FormatPlugin {
 
     private Map<XMLNamespace, String> namespacePrefix = new HashMap<>();
 
-    @Override
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
-                        justification = "Valid output from LYV is dependent on Logback output")
-    public void emitFormat() {
-        if (testedModule != null) {
+            justification = "Valid output from LYV is dependent on Logback output")
+    @Override
+    public void emitFormat(final Module module) {
+        if (module != null) {
             namespacePrefix = new HashMap<>();
             final SingletonListInitializer singletonListInitializer = new SingletonListInitializer(1);
 
             // Nodes
-            printLines(getChildNodesLines(singletonListInitializer, testedModule));
+            printLines(getChildNodesLines(singletonListInitializer, module));
 
             // Augmentations
-            for (final AugmentationSchemaNode augNode : testedModule.getAugmentations()) {
+            for (final AugmentationSchemaNode augNode : module.getAugmentations()) {
                 printLines(getAugmentationNodesLines(singletonListInitializer.getSingletonListWithIncreasedValue(),
                         augNode));
             }
 
             // Rpcs
-            printLines(getRpcsLines(singletonListInitializer, testedModule));
+            printLines(getRpcsLines(singletonListInitializer, module));
 
             // Notifications
-            printLines(getNotificationsLines(singletonListInitializer, testedModule));
+            printLines(getNotificationsLines(singletonListInitializer, module));
 
             LOG.info("</table>");
             LOG.info("</div>");

--- a/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
+++ b/src/main/java/io/lighty/yang/validator/formats/JsonTree.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.eclipse.jdt.annotation.Nullable;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opendaylight.yangtools.yang.common.QName;
 import org.opendaylight.yangtools.yang.common.Revision;
@@ -86,29 +87,31 @@ public class JsonTree extends FormatPlugin {
     private static final String SLASH = "/";
     private static final String COLON = ":";
 
+    private JSONArray parsedModels;
+
     @Override
-    void init(final EffectiveModelContext context, final Module module, final SchemaTree schemaTree,
-            final Configuration config) {
-        super.init(context, module, schemaTree, config);
+    void init(final EffectiveModelContext context, final SchemaTree schemaTree, final Configuration config) {
+        super.init(context, schemaTree, config);
+        this.parsedModels = new JSONArray();
     }
 
-    @Override
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
-                        justification = "Valid output from LYV is dependent on Logback output")
-    public void emitFormat() {
-        if (testedModule != null) {
+            justification = "Valid output from LYV is dependent on Logback output")
+    @Override
+    public void emitFormat(final Module module) {
+        if (module != null) {
             final LyvStack stack = new LyvStack();
-            final JSONObject moduleMetadata = resolveModuleMetadata(testedModule);
+            final JSONObject moduleMetadata = resolveModuleMetadata(module);
             final JSONObject jsonTree = new JSONObject();
 
-            appendChildNodesToJsonTree(testedModule, jsonTree, stack);
+            appendChildNodesToJsonTree(module, jsonTree, stack);
             stack.clear();
-            appendNotificationsToJsonTree(testedModule, jsonTree, stack);
+            appendNotificationsToJsonTree(module, jsonTree, stack);
             stack.clear();
-            appendRpcsToJsonTree(testedModule, jsonTree, stack);
+            appendRpcsToJsonTree(module, jsonTree, stack);
             stack.clear();
 
-            for (final AugmentationSchemaNode augmentation : testedModule.getAugmentations()) {
+            for (final AugmentationSchemaNode augmentation : module.getAugmentations()) {
                 stack.enter(augmentation.getTargetPath());
                 final JSONObject augmentationJson = new JSONObject();
                 final boolean isConfig = isAugmentConfig(augmentation);
@@ -129,16 +132,22 @@ public class JsonTree extends FormatPlugin {
                 }
 
                 appendActionsToAugmentationJson(augmentation, augmentationJson, stack);
-                appendNotificationsToAugmentationJson(testedModule, augmentationJson, stack);
+                appendNotificationsToAugmentationJson(module, augmentationJson, stack);
                 jsonTree.append(AUGMENTS, augmentationJson);
                 stack.clear();
             }
             jsonTree.put(MODULE, moduleMetadata);
-            final String jsonTreeText = jsonTree.toString(4);
-            LOG.info("{}", jsonTreeText);
+            parsedModels.put(jsonTree);
         } else {
             LOG.error("{}", EMPTY_MODULE_EXCEPTION);
         }
+    }
+
+    @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
+            justification = "Valid output from LYV is dependent on Logback output")
+    @Override
+    public void close() {
+        LOG.info("{}", new JSONObject().put("parsed-models", parsedModels).toString(4));
     }
 
     private void appendNotificationsToAugmentationJson(final Module module, final JSONObject augmentationJson,

--- a/src/main/java/io/lighty/yang/validator/formats/MultiModulePrinter.java
+++ b/src/main/java/io/lighty/yang/validator/formats/MultiModulePrinter.java
@@ -49,8 +49,8 @@ public class MultiModulePrinter extends FormatPlugin {
     private final Map<QNameModule, Set<SchemaTree>> subtrees = new HashMap<>();
 
     @Override
-    protected void emitFormat() {
-        if (testedModule != null) {
+    protected void emitFormat(final Module module) {
+        if (module != null) {
             splitTree(this.schemaTree);
             if (this.output != null) {
                 try {
@@ -66,13 +66,13 @@ public class MultiModulePrinter extends FormatPlugin {
                 subtrees.putIfAbsent(name, Collections.emptySet());
             }
             //print each yang module
-            printEachYangModule();
+            printEachYangModule(module);
         } else {
             LOG.error(EMPTY_MODULE_EXCEPTION);
         }
     }
 
-    private void printEachYangModule() {
+    private void printEachYangModule(Module testedModule) {
         for (final Map.Entry<QNameModule, Set<SchemaTree>> entry : subtrees.entrySet()) {
             final Module module = this.modelContext.findModule(entry.getKey())
                     .orElseThrow(() -> new NotFoundException(MODULE_STRING, entry.getKey().toString()));

--- a/src/main/java/io/lighty/yang/validator/formats/NameRevision.java
+++ b/src/main/java/io/lighty/yang/validator/formats/NameRevision.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.lighty.yang.validator.GroupArguments;
 import java.util.Optional;
 import org.opendaylight.yangtools.yang.common.Revision;
+import org.opendaylight.yangtools.yang.model.api.Module;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,10 +26,10 @@ public class NameRevision extends FormatPlugin {
     @Override
     @SuppressFBWarnings(value = "SLF4J_SIGN_ONLY_FORMAT",
                         justification = "Valid output from LYV is dependent on Logback output")
-    public void emitFormat() {
-        if (testedModule != null) {
-            final Optional<Revision> revision = testedModule.getRevision();
-            String moduleName = testedModule.getName();
+    public void emitFormat(final Module module) {
+        if (module != null) {
+            final Optional<Revision> revision = module.getRevision();
+            String moduleName = module.getName();
             if (revision.isPresent()) {
                 moduleName += ET + revision.get();
             }

--- a/src/test/java/io/lighty/yang/validator/MainTest.java
+++ b/src/test/java/io/lighty/yang/validator/MainTest.java
@@ -73,8 +73,8 @@ public class MainTest implements Cleanable {
                 .setOutput(outPath)
                 .build();
         for (final Module module : effectiveModelContext.getModules()) {
-            format.init(config, effectiveModelContext, module, schemaTree);
-            format.emit();
+            format.init(config, effectiveModelContext, schemaTree);
+            format.emit(module);
         }
         contextFactory =
                 new YangContextFactory(ImmutableList.of(outPath), ImmutableList.of(), Collections.emptySet(), false);

--- a/src/test/java/io/lighty/yang/validator/formats/JsonTreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/JsonTreeTest.java
@@ -7,13 +7,18 @@
  */
 package io.lighty.yang.validator.formats;
 
+import static io.lighty.yang.validator.Main.startLyv;
+
+import com.google.common.collect.ImmutableList;
 import io.lighty.yang.validator.FormatTest;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 public class JsonTreeTest extends FormatTest {
 
@@ -53,6 +58,35 @@ public class JsonTreeTest extends FormatTest {
     @Override
     public void runDeviationTest() throws Exception {
         runJsonTreeTest("ModuleDeviation.json");
+    }
+
+    @Test
+    public void testMultipleFiles() throws IOException {
+        final String module1 = Paths.get(yangPath + "/ietf-connection-oriented-oam@2019-04-16.yang").toString();
+        final String module2 = Paths.get(yangPath + "/ietf-routing@2018-03-13.yang").toString();
+        builder.setYangModules(ImmutableList.of(module1, module2));
+        final List<FormatPlugin> formats = new ArrayList<>();
+        formats.add(new JsonTree());
+        formatter = new Format(formats);
+        builder.setFormat("json-tree");
+        final var configuration = builder.build();
+        startLyv(configuration, formatter);
+        final Path outLog = Paths.get(outPath).resolve("out.log");
+        String fileCreated = Files.readString(outLog);
+        fileCreated = fileCreated.substring(fileCreated.indexOf("{"));
+        final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve("multipleModules.json"));
+        final String compareModel1 = Files.readString(
+                outLog.resolveSibling("compare").resolve("connectionOrientedOam.json"))
+                .replaceFirst("\\{\\s+\"parsed-models\": \\[\\s+\\{\n", "")
+                .replaceFirst("]\n\\s*}$", "").replaceAll("\\n\\s*", "");
+        final String compareModel2 = Files.readString(
+                outLog.resolveSibling("compare").resolve("routing.json"))
+                .replaceFirst("\\{\\s+\"parsed-models\": \\[\\s+\\{\n", "")
+                .replaceFirst("]\n\\s*}$", "").replaceAll("\\n\\s*", "");
+
+        Assert.assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        Assert.assertTrue(fileCreated.replaceAll("\\s+", "").contains(compareModel1.replaceAll("\\s+", "")));
+        Assert.assertTrue(fileCreated.replaceAll("\\s+", "").contains(compareModel2.replaceAll("\\s+", "")));
     }
 
     private void runJsonTreeTest(final String comapreWithFileName) throws Exception {

--- a/src/test/resources/integration/compare/integrationTestJsonTree.json
+++ b/src/test/resources/integration/compare/integrationTestJsonTree.json
@@ -1,4 +1,4 @@
-{
+{"parsed-models": [{
     "children": [
         {
             "path": "/test:result-container/",
@@ -379,4 +379,4 @@
             "status": "CURRENT"
         }
     ]
-}
+}]}

--- a/src/test/resources/out/compare/ModuleDeviation.json
+++ b/src/test/resources/out/compare/ModuleDeviation.json
@@ -1,47 +1,185 @@
-{"module": {
-  "prefix": "dev",
-  "contact": "",
-  "name": "deviation",
-  "namespace": "urn:ietf:params:xml:ns:yang:deviation",
-  "description": "",
-  "revision": "2022-11-30"
-}}
 {
-  "children": [{
-    "path": "/mo:data-container/",
-    "type_info": {},
-    "children": [
-      {
-        "path": "/mo:data-container/mo:list-data/",
+  "parsed-models": [
+    {"module": {
+      "prefix": "dev",
+      "contact": "",
+      "name": "deviation",
+      "namespace": "urn:ietf:params:xml:ns:yang:deviation",
+      "description": "",
+      "revision": "2022-11-30"
+    }}
+
+  ,
+    {
+      "children": [{
+        "path": "/mo:data-container/",
         "type_info": {},
         "children": [
           {
-            "path": "/mo:data-container/mo:list-data/mo:name/",
+            "path": "/mo:data-container/mo:list-data/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/mo:data-container/mo:list-data/mo:name/",
+                "type_info": {
+                  "description": "",
+                  "type": "string"
+                },
+                "children": [],
+                "name": "name",
+                "description": "",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/mo:data-container/mo:list-data/mo:year/",
+                "type_info": {
+                  "description": "",
+                  "type": "int8"
+                },
+                "children": [],
+                "name": "year",
+                "description": "",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/mo:data-container/mo:list-data/mo:sub-device/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/mo:data-container/mo:list-data/mo:sub-device/mo:type/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "type",
+                    "description": "",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/mo:data-container/mo:list-data/mo:sub-device/mo:state/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "state",
+                    "description": "",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "sub-device",
+                "description": "",
+                "config": true,
+                "class": "list",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "list-data",
+            "description": "",
+            "config": true,
+            "class": "list",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/mo:data-container/mo:country/",
             "type_info": {
               "description": "",
               "type": "string"
             },
             "children": [],
-            "name": "name",
+            "name": "country",
             "description": "",
             "config": true,
             "class": "leaf",
             "status": "CURRENT"
           },
           {
-            "path": "/mo:data-container/mo:list-data/mo:year/",
+            "path": "/mo:data-container/mo:device/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/mo:data-container/mo:device/mo:enumType/",
+                "type_info": {
+                  "description": "",
+                  "type": "mo:enumeration"
+                },
+                "children": [],
+                "name": "enumType",
+                "description": "",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/mo:data-container/mo:device/mo:model/",
+                "type_info": {
+                  "default": "15",
+                  "description": "",
+                  "type": "mo:model"
+                },
+                "children": [],
+                "name": "model",
+                "description": "",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "device",
+            "description": "",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "data-container",
+        "description": "",
+        "config": true,
+        "class": "container",
+        "status": "CURRENT"
+      }],
+      "module": {
+        "prefix": "mo",
+        "contact": "",
+        "name": "model",
+        "namespace": "urn:ietf:params:xml:ns:yang:model",
+        "description": "",
+        "revision": "2022-11-30"
+      },
+      "augments": [
+        {
+          "path": "/mo:data-container/mo:list-data/",
+          "children": [{
+            "path": "/mo:data-container/mo:list-data/mo:month/",
             "type_info": {
               "description": "",
-              "type": "int8"
+              "type": "string"
             },
             "children": [],
-            "name": "year",
+            "name": "month",
             "description": "",
             "config": true,
             "class": "leaf",
             "status": "CURRENT"
-          },
-          {
+          }],
+          "name": "/mo:data-container/mo:list-data/",
+          "description": "",
+          "config": true,
+          "class": "augmentation",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/mo:data-container/mo:list-data/",
+          "children": [{
             "path": "/mo:data-container/mo:list-data/mo:sub-device/",
             "type_info": {},
             "children": [
@@ -53,6 +191,19 @@
                 },
                 "children": [],
                 "name": "type",
+                "description": "",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/mo:data-container/mo:list-data/mo:sub-device/mo:year/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "year",
                 "description": "",
                 "config": true,
                 "class": "leaf",
@@ -77,50 +228,50 @@
             "config": true,
             "class": "list",
             "status": "CURRENT"
-          }
-        ],
-        "name": "list-data",
-        "description": "",
-        "config": true,
-        "class": "list",
-        "status": "CURRENT"
-      },
-      {
-        "path": "/mo:data-container/mo:country/",
-        "type_info": {
+          }],
+          "name": "/mo:data-container/mo:list-data/",
           "description": "",
-          "type": "string"
+          "config": true,
+          "class": "augmentation",
+          "status": "CURRENT"
         },
-        "children": [],
-        "name": "country",
-        "description": "",
-        "config": true,
-        "class": "leaf",
-        "status": "CURRENT"
-      },
-      {
-        "path": "/mo:data-container/mo:device/",
-        "type_info": {},
-        "children": [
-          {
-            "path": "/mo:data-container/mo:device/mo:enumType/",
-            "type_info": {
+        {
+          "path": "/mo:data-container/",
+          "children": [{
+            "path": "/mo:data-container/mo:device/",
+            "type_info": {},
+            "children": [{
+              "path": "/mo:data-container/mo:device/mo:enumType/",
+              "type_info": {
+                "description": "",
+                "type": "mo:enumeration"
+              },
+              "children": [],
+              "name": "enumType",
               "description": "",
-              "type": "mo:enumeration"
-            },
-            "children": [],
-            "name": "enumType",
+              "config": true,
+              "class": "leaf",
+              "status": "CURRENT"
+            }],
+            "name": "device",
             "description": "",
             "config": true,
-            "class": "leaf",
+            "class": "container",
             "status": "CURRENT"
-          },
-          {
+          }],
+          "name": "/mo:data-container/",
+          "description": "",
+          "config": true,
+          "class": "augmentation",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/mo:data-container/mo:device/",
+          "children": [{
             "path": "/mo:data-container/mo:device/mo:model/",
             "type_info": {
-              "default": "15",
               "description": "",
-              "type": "mo:model"
+              "type": "string"
             },
             "children": [],
             "name": "model",
@@ -128,180 +279,35 @@
             "config": true,
             "class": "leaf",
             "status": "CURRENT"
-          }
-        ],
-        "name": "device",
-        "description": "",
-        "config": true,
-        "class": "container",
-        "status": "CURRENT"
-      }
-    ],
-    "name": "data-container",
-    "description": "",
-    "config": true,
-    "class": "container",
-    "status": "CURRENT"
-  }],
-  "module": {
-    "prefix": "mo",
-    "contact": "",
-    "name": "model",
-    "namespace": "urn:ietf:params:xml:ns:yang:model",
-    "description": "",
-    "revision": "2022-11-30"
-  },
-  "augments": [
-    {
-      "path": "/mo:data-container/mo:list-data/",
-      "children": [{
-        "path": "/mo:data-container/mo:list-data/mo:month/",
-        "type_info": {
-          "description": "",
-          "type": "string"
-        },
-        "children": [],
-        "name": "month",
-        "description": "",
-        "config": true,
-        "class": "leaf",
-        "status": "CURRENT"
-      }],
-      "name": "/mo:data-container/mo:list-data/",
-      "description": "",
-      "config": true,
-      "class": "augmentation",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/mo:data-container/mo:list-data/",
-      "children": [{
-        "path": "/mo:data-container/mo:list-data/mo:sub-device/",
-        "type_info": {},
-        "children": [
-          {
-            "path": "/mo:data-container/mo:list-data/mo:sub-device/mo:type/",
-            "type_info": {
-              "description": "",
-              "type": "string"
-            },
-            "children": [],
-            "name": "type",
-            "description": "",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/mo:data-container/mo:list-data/mo:sub-device/mo:year/",
-            "type_info": {
-              "description": "",
-              "type": "uint8"
-            },
-            "children": [],
-            "name": "year",
-            "description": "",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/mo:data-container/mo:list-data/mo:sub-device/mo:state/",
-            "type_info": {
-              "description": "",
-              "type": "string"
-            },
-            "children": [],
-            "name": "state",
-            "description": "",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          }
-        ],
-        "name": "sub-device",
-        "description": "",
-        "config": true,
-        "class": "list",
-        "status": "CURRENT"
-      }],
-      "name": "/mo:data-container/mo:list-data/",
-      "description": "",
-      "config": true,
-      "class": "augmentation",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/mo:data-container/",
-      "children": [{
-        "path": "/mo:data-container/mo:device/",
-        "type_info": {},
-        "children": [{
-          "path": "/mo:data-container/mo:device/mo:enumType/",
-          "type_info": {
-            "description": "",
-            "type": "mo:enumeration"
-          },
-          "children": [],
-          "name": "enumType",
+          }],
+          "name": "/mo:data-container/mo:device/",
           "description": "",
           "config": true,
-          "class": "leaf",
+          "class": "augmentation",
           "status": "CURRENT"
-        }],
-        "name": "device",
-        "description": "",
-        "config": true,
-        "class": "container",
-        "status": "CURRENT"
-      }],
-      "name": "/mo:data-container/",
-      "description": "",
-      "config": true,
-      "class": "augmentation",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/mo:data-container/mo:device/",
-      "children": [{
-        "path": "/mo:data-container/mo:device/mo:model/",
-        "type_info": {
-          "description": "",
-          "type": "string"
         },
-        "children": [],
-        "name": "model",
-        "description": "",
-        "config": true,
-        "class": "leaf",
-        "status": "CURRENT"
-      }],
-      "name": "/mo:data-container/mo:device/",
-      "description": "",
-      "config": true,
-      "class": "augmentation",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/mo:data-container/mo:device/",
-      "children": [{
-        "path": "/mo:data-container/mo:device/mo:manufacturer/",
-        "type_info": {
+        {
+          "path": "/mo:data-container/mo:device/",
+          "children": [{
+            "path": "/mo:data-container/mo:device/mo:manufacturer/",
+            "type_info": {
+              "description": "",
+              "type": "string"
+            },
+            "children": [],
+            "name": "manufacturer",
+            "description": "",
+            "config": true,
+            "class": "leaf",
+            "status": "CURRENT"
+          }],
+          "name": "/mo:data-container/mo:device/",
           "description": "",
-          "type": "string"
-        },
-        "children": [],
-        "name": "manufacturer",
-        "description": "",
-        "config": true,
-        "class": "leaf",
-        "status": "CURRENT"
-      }],
-      "name": "/mo:data-container/mo:device/",
-      "description": "",
-      "config": true,
-      "class": "augmentation",
-      "status": "CURRENT"
+          "config": true,
+          "class": "augmentation",
+          "status": "CURRENT"
+        }
+      ]
     }
   ]
 }

--- a/src/test/resources/out/compare/connectionOrientedOam.json
+++ b/src/test/resources/out/compare/connectionOrientedOam.json
@@ -1,337 +1,196 @@
 {
-  "children": [{
-    "path": "/co-oam:domains/",
-    "type_info": {},
-    "children": [{
-      "path": "/co-oam:domains/co-oam:domain/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/co-oam:domains/co-oam:domain/co-oam:technology/",
-          "type_info": {
-            "description": "",
-            "type": "identityref",
-            "base": ["technology-types"]
-          },
-          "children": [],
-          "name": "technology",
-          "description": "Defines the technology.",
-          "config": true,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:domains/co-oam:domain/co-oam:md-name-string/",
-          "type_info": {
-            "description": "Generic administrative name for Maintenance Domain (MD).",
-            "type": "co-oam:md-name-string"
-          },
-          "children": [],
-          "name": "md-name-string",
-          "description": "Defines the generic administrative Maintenance Domain name.",
-          "config": true,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:domains/co-oam:domain/co-oam:md-name-format/",
-          "type_info": {
-            "description": "",
-            "type": "identityref",
-            "base": ["name-format"]
-          },
-          "children": [],
-          "name": "md-name-format",
-          "description": "Maintenance Domain Name format.",
-          "config": true,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/",
+  "parsed-models": [
+    {
+      "children": [{
+        "path": "/co-oam:domains/",
+        "type_info": {},
+        "children": [{
+          "path": "/co-oam:domains/co-oam:domain/",
           "type_info": {},
-          "children": [{
-            "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/co-oam:md-name-null/",
-            "type_info": {},
-            "children": [{
-              "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/co-oam:md-name-null/co-oam:md-name-null/",
+          "children": [
+            {
+              "path": "/co-oam:domains/co-oam:domain/co-oam:technology/",
               "type_info": {
                 "description": "",
-                "type": "empty"
+                "type": "identityref",
+                "base": ["technology-types"]
               },
               "children": [],
-              "name": "md-name-null",
-              "description": "MD name null.",
+              "name": "technology",
+              "description": "Defines the technology.",
               "config": true,
               "class": "leaf",
               "status": "CURRENT"
-            }],
-            "name": "md-name-null",
-            "description": "",
-            "config": true,
-            "class": "case",
-            "status": "CURRENT"
-          }],
-          "name": "md-name",
-          "description": "MD name.",
-          "config": true,
-          "class": "choice",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:domains/co-oam:domain/co-oam:md-level/",
-          "type_info": {
-            "description": "Maintenance Domain Level.  The level may be restricted in\ncertain protocols (e.g., protocol in layer 0 to layer 7).",
-            "type": "co-oam:md-level"
-          },
-          "children": [],
-          "name": "md-level",
-          "description": "Define the MD level.",
-          "config": true,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/",
-          "type_info": {},
-          "children": [{
-            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/",
-            "type_info": {},
-            "children": [
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name-string/",
-                "type_info": {
-                  "description": "Generic administrative name for a\nMaintenance Association (MA).",
-                  "type": "co-oam:ma-name-string"
-                },
-                "children": [],
-                "name": "ma-name-string",
-                "description": "MA name string.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:domains/co-oam:domain/co-oam:md-name-string/",
+              "type_info": {
+                "description": "Generic administrative name for Maintenance Domain (MD).",
+                "type": "co-oam:md-name-string"
               },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name-format/",
-                "type_info": {
-                  "description": "",
-                  "type": "identityref",
-                  "base": ["name-format"]
-                },
-                "children": [],
-                "name": "ma-name-format",
-                "description": "MA name format.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
+              "children": [],
+              "name": "md-name-string",
+              "description": "Defines the generic administrative Maintenance Domain name.",
+              "config": true,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:domains/co-oam:domain/co-oam:md-name-format/",
+              "type_info": {
+                "description": "",
+                "type": "identityref",
+                "base": ["name-format"]
               },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/",
+              "children": [],
+              "name": "md-name-format",
+              "description": "Maintenance Domain Name format.",
+              "config": true,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/co-oam:md-name-null/",
                 "type_info": {},
                 "children": [{
-                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/co-oam:ma-name-null/",
-                  "type_info": {},
-                  "children": [{
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/co-oam:ma-name-null/co-oam:ma-name-null/",
-                    "type_info": {
-                      "description": "",
-                      "type": "empty"
-                    },
-                    "children": [],
-                    "name": "ma-name-null",
-                    "description": "Empty",
-                    "config": true,
-                    "class": "leaf",
-                    "status": "CURRENT"
-                  }],
-                  "name": "ma-name-null",
-                  "description": "",
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/co-oam:md-name-null/co-oam:md-name-null/",
+                  "type_info": {
+                    "description": "",
+                    "type": "empty"
+                  },
+                  "children": [],
+                  "name": "md-name-null",
+                  "description": "MD name null.",
                   "config": true,
-                  "class": "case",
+                  "class": "leaf",
                   "status": "CURRENT"
                 }],
-                "name": "ma-name",
-                "description": "MA name.",
+                "name": "md-name-null",
+                "description": "",
                 "config": true,
-                "class": "choice",
+                "class": "case",
                 "status": "CURRENT"
+              }],
+              "name": "md-name",
+              "description": "MD name.",
+              "config": true,
+              "class": "choice",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:domains/co-oam:domain/co-oam:md-level/",
+              "type_info": {
+                "description": "Maintenance Domain Level.  The level may be restricted in\ncertain protocols (e.g., protocol in layer 0 to layer 7).",
+                "type": "co-oam:md-level"
               },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/",
-                "type_info": {},
-                "children": [{
-                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/co-oam:context-null/",
-                  "type_info": {},
-                  "children": [{
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/co-oam:context-null/co-oam:context-null/",
-                    "type_info": {
-                      "description": "",
-                      "type": "empty"
-                    },
-                    "children": [],
-                    "name": "context-null",
-                    "description": "There is no context to be defined.",
-                    "config": true,
-                    "class": "leaf",
-                    "status": "CURRENT"
-                  }],
-                  "name": "context-null",
-                  "description": "This is a placeholder when no context is needed.",
-                  "config": true,
-                  "class": "case",
-                  "status": "CURRENT"
-                }],
-                "name": "connectivity-context",
-                "description": "Connectivity context.",
-                "config": true,
-                "class": "choice",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:cos-id/",
-                "type_info": {
-                  "description": "",
-                  "type": "uint8"
-                },
-                "children": [],
-                "name": "cos-id",
-                "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:cc-enable/",
-                "type_info": {
-                  "description": "",
-                  "type": "boolean"
-                },
-                "children": [],
-                "name": "cc-enable",
-                "description": "Indicate whether the CC is enabled.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/",
+              "children": [],
+              "name": "md-level",
+              "description": "Define the MD level.",
+              "config": true,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/",
                 "type_info": {},
                 "children": [
                   {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-name/",
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name-string/",
                     "type_info": {
-                      "description": "Generic administrative name for a MEP.",
-                      "type": "co-oam:mep-name"
+                      "description": "Generic administrative name for a\nMaintenance Association (MA).",
+                      "type": "co-oam:ma-name-string"
                     },
                     "children": [],
-                    "name": "mep-name",
-                    "description": "Generic administrative name of the\nMEP.",
+                    "name": "ma-name-string",
+                    "description": "MA name string.",
                     "config": true,
                     "class": "leaf",
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/",
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name-format/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["name-format"]
+                    },
+                    "children": [],
+                    "name": "ma-name-format",
+                    "description": "MA name format.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/",
                     "type_info": {},
                     "children": [{
-                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/co-oam:mep-id-int/",
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/co-oam:ma-name-null/",
                       "type_info": {},
                       "children": [{
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/co-oam:ma-name-null/co-oam:ma-name-null/",
                         "type_info": {
                           "description": "",
-                          "type": "int32"
+                          "type": "empty"
                         },
                         "children": [],
-                        "name": "mep-id-int",
-                        "description": "MEP ID\nin integer format.",
+                        "name": "ma-name-null",
+                        "description": "Empty",
                         "config": true,
                         "class": "leaf",
                         "status": "CURRENT"
                       }],
-                      "name": "mep-id-int",
+                      "name": "ma-name-null",
                       "description": "",
                       "config": true,
                       "class": "case",
                       "status": "CURRENT"
                     }],
-                    "name": "mep-id",
-                    "description": "MEP ID.",
+                    "name": "ma-name",
+                    "description": "MA name.",
                     "config": true,
                     "class": "choice",
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id-format/",
-                    "type_info": {
-                      "description": "",
-                      "type": "identityref",
-                      "base": ["identifier-format"]
-                    },
-                    "children": [],
-                    "name": "mep-id-format",
-                    "description": "MEP ID format.",
-                    "config": true,
-                    "class": "leaf",
-                    "status": "CURRENT"
-                  },
-                  {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/",
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/",
                     "type_info": {},
-                    "children": [
-                      {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:mac-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
-                          "type_info": {
-                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                            "type": "yang:mac-address"
-                          },
-                          "children": [],
-                          "name": "mac-address",
-                          "description": "MAC Address.",
-                          "config": true,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "mac-address",
-                        "description": "MAC Address based MEP Addressing.",
+                    "children": [{
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/co-oam:context-null/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/co-oam:context-null/co-oam:context-null/",
+                        "type_info": {
+                          "description": "",
+                          "type": "empty"
+                        },
+                        "children": [],
+                        "name": "context-null",
+                        "description": "There is no context to be defined.",
                         "config": true,
-                        "class": "case",
+                        "class": "leaf",
                         "status": "CURRENT"
-                      },
-                      {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:ip-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
-                          "type_info": {
-                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                            "type": "inet:ip-address"
-                          },
-                          "children": [],
-                          "name": "ip-address",
-                          "description": "IP Address.",
-                          "config": true,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "ip-address",
-                        "description": "IP Address based MEP Addressing.",
-                        "config": true,
-                        "class": "case",
-                        "status": "CURRENT"
-                      }
-                    ],
-                    "name": "mep-address",
-                    "description": "MEP Addressing.",
+                      }],
+                      "name": "context-null",
+                      "description": "This is a placeholder when no context is needed.",
+                      "config": true,
+                      "class": "case",
+                      "status": "CURRENT"
+                    }],
+                    "name": "connectivity-context",
+                    "description": "Connectivity context.",
                     "config": true,
                     "class": "choice",
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:cos-id/",
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:cos-id/",
                     "type_info": {
                       "description": "",
                       "type": "uint8"
@@ -344,7 +203,7 @@
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:cc-enable/",
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:cc-enable/",
                     "type_info": {
                       "description": "",
                       "type": "boolean"
@@ -357,144 +216,124 @@
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/",
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/",
                     "type_info": {},
                     "children": [
                       {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:session-cookie/",
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-name/",
                         "type_info": {
-                          "description": "",
-                          "type": "uint32"
+                          "description": "Generic administrative name for a MEP.",
+                          "type": "co-oam:mep-name"
                         },
                         "children": [],
-                        "name": "session-cookie",
-                        "description": "Cookie to identify different sessions, when there\nare multiple remote MEPs or multiple sessions to\nthe same remote MEP.",
+                        "name": "mep-name",
+                        "description": "Generic administrative name of the\nMEP.",
                         "config": true,
                         "class": "leaf",
                         "status": "CURRENT"
                       },
                       {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/",
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/",
                         "type_info": {},
-                        "children": [
-                          {
-                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
-                              "type_info": {},
-                              "children": [{
-                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
-                                "type_info": {
-                                  "description": "",
-                                  "type": "int32"
-                                },
-                                "children": [],
-                                "name": "mep-id-int",
-                                "description": "MEP ID\nin integer format.",
-                                "config": true,
-                                "class": "leaf",
-                                "status": "CURRENT"
-                              }],
-                              "name": "mep-id-int",
-                              "description": "",
-                              "config": true,
-                              "class": "case",
-                              "status": "CURRENT"
-                            }],
-                            "name": "mep-id",
-                            "description": "MEP ID.",
-                            "config": true,
-                            "class": "choice",
-                            "status": "CURRENT"
-                          },
-                          {
-                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id-format/",
+                        "children": [{
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/co-oam:mep-id-int/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
                             "type_info": {
                               "description": "",
-                              "type": "identityref",
-                              "base": ["identifier-format"]
+                              "type": "int32"
                             },
                             "children": [],
-                            "name": "mep-id-format",
-                            "description": "MEP ID format.",
+                            "name": "mep-id-int",
+                            "description": "MEP ID\nin integer format.",
                             "config": true,
                             "class": "leaf",
                             "status": "CURRENT"
-                          }
-                        ],
-                        "name": "destination-mep",
-                        "description": "Destination MEP.",
-                        "config": true,
-                        "class": "container",
-                        "status": "CURRENT"
-                      },
-                      {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/",
-                          "type_info": {},
-                          "children": [
-                            {
-                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:mac-address/",
-                              "type_info": {},
-                              "children": [{
-                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
-                                "type_info": {
-                                  "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                                  "type": "yang:mac-address"
-                                },
-                                "children": [],
-                                "name": "mac-address",
-                                "description": "MAC Address.",
-                                "config": true,
-                                "class": "leaf",
-                                "status": "CURRENT"
-                              }],
-                              "name": "mac-address",
-                              "description": "MAC Address based MEP Addressing.",
-                              "config": true,
-                              "class": "case",
-                              "status": "CURRENT"
-                            },
-                            {
-                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:ip-address/",
-                              "type_info": {},
-                              "children": [{
-                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
-                                "type_info": {
-                                  "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                                  "type": "inet:ip-address"
-                                },
-                                "children": [],
-                                "name": "ip-address",
-                                "description": "IP Address.",
-                                "config": true,
-                                "class": "leaf",
-                                "status": "CURRENT"
-                              }],
-                              "name": "ip-address",
-                              "description": "IP Address based MEP Addressing.",
-                              "config": true,
-                              "class": "case",
-                              "status": "CURRENT"
-                            }
-                          ],
-                          "name": "mep-address",
-                          "description": "MEP Addressing.",
+                          }],
+                          "name": "mep-id-int",
+                          "description": "",
                           "config": true,
-                          "class": "choice",
+                          "class": "case",
                           "status": "CURRENT"
                         }],
-                        "name": "destination-mep-address",
-                        "description": "Destination MEP Address.",
+                        "name": "mep-id",
+                        "description": "MEP ID.",
                         "config": true,
-                        "class": "container",
+                        "class": "choice",
                         "status": "CURRENT"
                       },
                       {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:cos-id/",
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id-format/",
+                        "type_info": {
+                          "description": "",
+                          "type": "identityref",
+                          "base": ["identifier-format"]
+                        },
+                        "children": [],
+                        "name": "mep-id-format",
+                        "description": "MEP ID format.",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:mac-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                              "type_info": {
+                                "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                                "type": "yang:mac-address"
+                              },
+                              "children": [],
+                              "name": "mac-address",
+                              "description": "MAC Address.",
+                              "config": true,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "mac-address",
+                            "description": "MAC Address based MEP Addressing.",
+                            "config": true,
+                            "class": "case",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:ip-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                              "type_info": {
+                                "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                                "type": "inet:ip-address"
+                              },
+                              "children": [],
+                              "name": "ip-address",
+                              "description": "IP Address.",
+                              "config": true,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "ip-address",
+                            "description": "IP Address based MEP Addressing.",
+                            "config": true,
+                            "class": "case",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "mep-address",
+                        "description": "MEP Addressing.",
+                        "config": true,
+                        "class": "choice",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:cos-id/",
                         "type_info": {
                           "description": "",
                           "type": "uint8"
@@ -505,1246 +344,594 @@
                         "config": true,
                         "class": "leaf",
                         "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:cc-enable/",
+                        "type_info": {
+                          "description": "",
+                          "type": "boolean"
+                        },
+                        "children": [],
+                        "name": "cc-enable",
+                        "description": "Indicate whether the CC is enabled.",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:session-cookie/",
+                            "type_info": {
+                              "description": "",
+                              "type": "uint32"
+                            },
+                            "children": [],
+                            "name": "session-cookie",
+                            "description": "Cookie to identify different sessions, when there\nare multiple remote MEPs or multiple sessions to\nthe same remote MEP.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/",
+                            "type_info": {},
+                            "children": [
+                              {
+                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/",
+                                "type_info": {},
+                                "children": [{
+                                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                                    "type_info": {
+                                      "description": "",
+                                      "type": "int32"
+                                    },
+                                    "children": [],
+                                    "name": "mep-id-int",
+                                    "description": "MEP ID\nin integer format.",
+                                    "config": true,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "mep-id-int",
+                                  "description": "",
+                                  "config": true,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                }],
+                                "name": "mep-id",
+                                "description": "MEP ID.",
+                                "config": true,
+                                "class": "choice",
+                                "status": "CURRENT"
+                              },
+                              {
+                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id-format/",
+                                "type_info": {
+                                  "description": "",
+                                  "type": "identityref",
+                                  "base": ["identifier-format"]
+                                },
+                                "children": [],
+                                "name": "mep-id-format",
+                                "description": "MEP ID format.",
+                                "config": true,
+                                "class": "leaf",
+                                "status": "CURRENT"
+                              }
+                            ],
+                            "name": "destination-mep",
+                            "description": "Destination MEP.",
+                            "config": true,
+                            "class": "container",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/",
+                              "type_info": {},
+                              "children": [
+                                {
+                                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:mac-address/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                                    "type_info": {
+                                      "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                                      "type": "yang:mac-address"
+                                    },
+                                    "children": [],
+                                    "name": "mac-address",
+                                    "description": "MAC Address.",
+                                    "config": true,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "mac-address",
+                                  "description": "MAC Address based MEP Addressing.",
+                                  "config": true,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                },
+                                {
+                                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:ip-address/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                                    "type_info": {
+                                      "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                                      "type": "inet:ip-address"
+                                    },
+                                    "children": [],
+                                    "name": "ip-address",
+                                    "description": "IP Address.",
+                                    "config": true,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "ip-address",
+                                  "description": "IP Address based MEP Addressing.",
+                                  "config": true,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                }
+                              ],
+                              "name": "mep-address",
+                              "description": "MEP Addressing.",
+                              "config": true,
+                              "class": "choice",
+                              "status": "CURRENT"
+                            }],
+                            "name": "destination-mep-address",
+                            "description": "Destination MEP Address.",
+                            "config": true,
+                            "class": "container",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:cos-id/",
+                            "type_info": {
+                              "description": "",
+                              "type": "uint8"
+                            },
+                            "children": [],
+                            "name": "cos-id",
+                            "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "session",
+                        "description": "Monitoring session to/from a particular remote MEP.\nDepending on the protocol, this could represent\nCC messages received from a single remote MEP (if the\nprotocol uses multicast CCs) or a target to which\nunicast echo request CCs are sent and from which\nresponses are received (if the protocol uses a\nunicast request/response mechanism).",
+                        "config": true,
+                        "class": "list",
+                        "status": "CURRENT"
                       }
                     ],
-                    "name": "session",
-                    "description": "Monitoring session to/from a particular remote MEP.\nDepending on the protocol, this could represent\nCC messages received from a single remote MEP (if the\nprotocol uses multicast CCs) or a target to which\nunicast echo request CCs are sent and from which\nresponses are received (if the protocol uses a\nunicast request/response mechanism).",
+                    "name": "mep",
+                    "description": "Contain a list of MEPs.",
+                    "config": true,
+                    "class": "list",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:name/",
+                        "type_info": {
+                          "description": "",
+                          "type": "string"
+                        },
+                        "children": [],
+                        "name": "name",
+                        "description": "Identifier of Maintenance Intermediate Point",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:interface/",
+                        "type_info": {
+                          "description": "This type is used by data models that need to reference\ninterfaces.",
+                          "type": "if:interface-ref"
+                        },
+                        "children": [],
+                        "name": "interface",
+                        "description": "Interface.",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:mac-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:mac-address/co-oam:mac-address/",
+                              "type_info": {
+                                "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                                "type": "yang:mac-address"
+                              },
+                              "children": [],
+                              "name": "mac-address",
+                              "description": "MAC Address of Maintenance Intermediate Point",
+                              "config": true,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "mac-address",
+                            "description": "MAC Address based MIP Addressing.",
+                            "config": true,
+                            "class": "case",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:ip-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:ip-address/co-oam:ip-address/",
+                              "type_info": {
+                                "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                                "type": "inet:ip-address"
+                              },
+                              "children": [],
+                              "name": "ip-address",
+                              "description": "IP Address.",
+                              "config": true,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "ip-address",
+                            "description": "IP Address based MIP Addressing.",
+                            "config": true,
+                            "class": "case",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "mip-address",
+                        "description": "MIP Addressing.",
+                        "config": true,
+                        "class": "choice",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "mip",
+                    "description": "List for MIP.",
                     "config": true,
                     "class": "list",
                     "status": "CURRENT"
                   }
                 ],
-                "name": "mep",
-                "description": "Contain a list of MEPs.",
+                "name": "ma",
+                "description": "Maintenance Association list.",
                 "config": true,
                 "class": "list",
                 "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/",
-                "type_info": {},
-                "children": [
-                  {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:name/",
-                    "type_info": {
-                      "description": "",
-                      "type": "string"
-                    },
-                    "children": [],
-                    "name": "name",
-                    "description": "Identifier of Maintenance Intermediate Point",
-                    "config": true,
-                    "class": "leaf",
-                    "status": "CURRENT"
+              }],
+              "name": "mas",
+              "description": "Contains configuration-related data.  Within the\ncontainer, there is a list of MAs.  Each MA has a\nlist of MEPs.",
+              "config": true,
+              "class": "container",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "domain",
+          "description": "Define a list of Domains within the\nietf-connection-oriented-oam module.",
+          "config": true,
+          "class": "list",
+          "status": "CURRENT"
+        }],
+        "name": "domains",
+        "description": "Contains configuration related data.  Within the\ncontainer, there is a list of fault domains.  Each\ndomain has a list of MAs.",
+        "config": true,
+        "class": "container",
+        "status": "CURRENT"
+      }],
+      "module": {
+        "prefix": "co-oam",
+        "contact": "WG Web:    http://datatracker.ietf.org/wg/lime\nWG List:   <mailto:lime@ietf.org>\nEditor:    Deepak Kumar <dekumar@cisco.com>\nEditor:    Qin Wu <bill.wu@huawei.com>\nEditor:    Michael Wang <wangzitao@huawei.com>",
+        "name": "ietf-connection-oriented-oam",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam",
+        "description": "This YANG module defines the generic configuration,\nstatistics and RPC for connection-oriented OAM\nto be used within IETF in a protocol-independent manner.\nFunctional-level abstraction is independent\nwith YANG modeling. It is assumed that each protocol\nmaps corresponding abstracts to its native format.\nEach protocol may extend the YANG data model defined\nhere to include protocol-specific extensions\n\nCopyright (c) 2019 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(http://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8531; see\nthe RFC itself for full legal notices.",
+        "revision": "2019-04-16"
+      },
+      "rpcs": [
+        {
+          "path": "/co-oam:continuity-check/",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/co-oam:continuity-check/co-oam:input/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:technology/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["technology-types"]
                   },
-                  {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:interface/",
-                    "type_info": {
-                      "description": "This type is used by data models that need to reference\ninterfaces.",
-                      "type": "if:interface-ref"
-                    },
-                    "children": [],
-                    "name": "interface",
-                    "description": "Interface.",
-                    "config": true,
-                    "class": "leaf",
-                    "status": "CURRENT"
+                  "children": [],
+                  "name": "technology",
+                  "description": "The technology.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:md-name-string/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
                   },
-                  {
-                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/",
-                    "type_info": {},
-                    "children": [
-                      {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:mac-address/",
+                  "children": [],
+                  "name": "md-name-string",
+                  "description": "Indicate which MD the defect belongs to.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:md-level/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "md-level",
+                  "description": "The Maintenance Domain Level.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:ma-name-string/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "ma-name-string",
+                  "description": "Indicate which MA the defect is associated with.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:cos-id/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "cos-id",
+                  "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:ttl/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "ttl",
+                  "description": "Time to Live.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:sub-type/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["command-sub-type"]
+                  },
+                  "children": [],
+                  "name": "sub-type",
+                  "description": "Defines different command types.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:source-mep/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "source-mep",
+                  "description": "Source MEP.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mep-address",
+                      "description": "MEP Addressing.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
                         "type_info": {},
                         "children": [{
-                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:mac-address/co-oam:mac-address/",
+                          "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
                           "type_info": {
-                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                            "type": "yang:mac-address"
+                            "description": "",
+                            "type": "int32"
                           },
                           "children": [],
-                          "name": "mac-address",
-                          "description": "MAC Address of Maintenance Intermediate Point",
+                          "name": "mep-id-int",
+                          "description": "MEP ID\nin integer format.",
                           "config": true,
                           "class": "leaf",
                           "status": "CURRENT"
                         }],
-                        "name": "mac-address",
-                        "description": "MAC Address based MIP Addressing.",
-                        "config": true,
-                        "class": "case",
-                        "status": "CURRENT"
-                      },
-                      {
-                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:ip-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:ip-address/co-oam:ip-address/",
-                          "type_info": {
-                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                            "type": "inet:ip-address"
-                          },
-                          "children": [],
-                          "name": "ip-address",
-                          "description": "IP Address.",
-                          "config": true,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "ip-address",
-                        "description": "IP Address based MIP Addressing.",
-                        "config": true,
-                        "class": "case",
-                        "status": "CURRENT"
-                      }
-                    ],
-                    "name": "mip-address",
-                    "description": "MIP Addressing.",
-                    "config": true,
-                    "class": "choice",
-                    "status": "CURRENT"
-                  }
-                ],
-                "name": "mip",
-                "description": "List for MIP.",
-                "config": true,
-                "class": "list",
-                "status": "CURRENT"
-              }
-            ],
-            "name": "ma",
-            "description": "Maintenance Association list.",
-            "config": true,
-            "class": "list",
-            "status": "CURRENT"
-          }],
-          "name": "mas",
-          "description": "Contains configuration-related data.  Within the\ncontainer, there is a list of MAs.  Each MA has a\nlist of MEPs.",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "domain",
-      "description": "Define a list of Domains within the\nietf-connection-oriented-oam module.",
-      "config": true,
-      "class": "list",
-      "status": "CURRENT"
-    }],
-    "name": "domains",
-    "description": "Contains configuration related data.  Within the\ncontainer, there is a list of fault domains.  Each\ndomain has a list of MAs.",
-    "config": true,
-    "class": "container",
-    "status": "CURRENT"
-  }],
-  "module": {
-    "prefix": "co-oam",
-    "contact": "WG Web:    http://datatracker.ietf.org/wg/lime\nWG List:   <mailto:lime@ietf.org>\nEditor:    Deepak Kumar <dekumar@cisco.com>\nEditor:    Qin Wu <bill.wu@huawei.com>\nEditor:    Michael Wang <wangzitao@huawei.com>",
-    "name": "ietf-connection-oriented-oam",
-    "namespace": "urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam",
-    "description": "This YANG module defines the generic configuration,\nstatistics and RPC for connection-oriented OAM\nto be used within IETF in a protocol-independent manner.\nFunctional-level abstraction is independent\nwith YANG modeling. It is assumed that each protocol\nmaps corresponding abstracts to its native format.\nEach protocol may extend the YANG data model defined\nhere to include protocol-specific extensions\n\nCopyright (c) 2019 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(http://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8531; see\nthe RFC itself for full legal notices.",
-    "revision": "2019-04-16"
-  },
-  "rpcs": [
-    {
-      "path": "/co-oam:continuity-check/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/co-oam:continuity-check/co-oam:input/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:technology/",
-              "type_info": {
-                "description": "",
-                "type": "identityref",
-                "base": ["technology-types"]
-              },
-              "children": [],
-              "name": "technology",
-              "description": "The technology.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:md-name-string/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "md-name-string",
-              "description": "Indicate which MD the defect belongs to.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:md-level/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "md-level",
-              "description": "The Maintenance Domain Level.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:ma-name-string/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "ma-name-string",
-              "description": "Indicate which MA the defect is associated with.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:cos-id/",
-              "type_info": {
-                "description": "",
-                "type": "uint8"
-              },
-              "children": [],
-              "name": "cos-id",
-              "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:ttl/",
-              "type_info": {
-                "description": "",
-                "type": "uint8"
-              },
-              "children": [],
-              "name": "ttl",
-              "description": "Time to Live.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:sub-type/",
-              "type_info": {
-                "description": "",
-                "type": "identityref",
-                "base": ["command-sub-type"]
-              },
-              "children": [],
-              "name": "sub-type",
-              "description": "Defines different command types.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:source-mep/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "source-mep",
-              "description": "Source MEP.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
-                  "type_info": {},
-                  "children": [
-                    {
-                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
-                        "type_info": {
-                          "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                          "type": "yang:mac-address"
-                        },
-                        "children": [],
-                        "name": "mac-address",
-                        "description": "MAC Address.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "mac-address",
-                      "description": "MAC Address based MEP Addressing.",
-                      "config": true,
-                      "class": "case",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
-                        "type_info": {
-                          "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                          "type": "inet:ip-address"
-                        },
-                        "children": [],
-                        "name": "ip-address",
-                        "description": "IP Address.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "ip-address",
-                      "description": "IP Address based MEP Addressing.",
-                      "config": true,
-                      "class": "case",
-                      "status": "CURRENT"
-                    }
-                  ],
-                  "name": "mep-address",
-                  "description": "MEP Addressing.",
-                  "config": true,
-                  "class": "choice",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
-                  "type_info": {},
-                  "children": [{
-                    "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
-                    "type_info": {},
-                    "children": [{
-                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
-                      "type_info": {
-                        "description": "",
-                        "type": "int32"
-                      },
-                      "children": [],
-                      "name": "mep-id-int",
-                      "description": "MEP ID\nin integer format.",
-                      "config": true,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    }],
-                    "name": "mep-id-int",
-                    "description": "",
-                    "config": true,
-                    "class": "case",
-                    "status": "CURRENT"
-                  }],
-                  "name": "mep-id",
-                  "description": "MEP ID.",
-                  "config": true,
-                  "class": "choice",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
-                  "type_info": {
-                    "description": "",
-                    "type": "identityref",
-                    "base": ["identifier-format"]
-                  },
-                  "children": [],
-                  "name": "mep-id-format",
-                  "description": "MEP ID format.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }
-              ],
-              "name": "destination-mep",
-              "description": "Destination MEP.",
-              "config": true,
-              "class": "container",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:count/",
-              "type_info": {
-                "default": "3",
-                "description": "Number of continuity-check messages to be sent.",
-                "type": "co-oam:count"
-              },
-              "children": [],
-              "name": "count",
-              "description": "Number of continuity-check messages to be sent.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:cc-transmit-interval/",
-              "type_info": {
-                "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
-                "type": "co-oam:time-interval"
-              },
-              "children": [],
-              "name": "cc-transmit-interval",
-              "description": "Time interval between echo requests.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-check/co-oam:input/co-oam:packet-size/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:uint32"
-              },
-              "children": [],
-              "name": "packet-size",
-              "description": "Size of continuity-check packets, in octets.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "input",
-          "description": "",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:continuity-check/co-oam:output/",
-          "type_info": {},
-          "children": [{
-            "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/",
-            "type_info": {},
-            "children": [{
-              "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/",
-              "type_info": {},
-              "children": [{
-                "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
-                "type_info": {
-                  "description": "",
-                  "type": "empty"
-                },
-                "children": [],
-                "name": "monitor-null",
-                "description": "There are no monitoring statistics to be defined.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              }],
-              "name": "monitor-null",
-              "description": "This is a placeholder when\nno monitoring statistics are needed.",
-              "config": false,
-              "class": "case",
-              "status": "CURRENT"
-            }],
-            "name": "monitor-stats",
-            "description": "Define the monitor stats.",
-            "config": false,
-            "class": "choice",
-            "status": "CURRENT"
-          }],
-          "name": "output",
-          "description": "",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "continuity-check",
-      "description": "Generates Continuity Check as per Table 4 of RFC 7276.",
-      "class": "rpc",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/co-oam:continuity-verification/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/co-oam:continuity-verification/co-oam:input/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:md-name-string/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "md-name-string",
-              "description": "Indicate which MD the defect belongs to.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:md-level/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "md-level",
-              "description": "The Maintenance Domain Level.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:ma-name-string/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "ma-name-string",
-              "description": "Indicate which MA the defect is associated with.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:cos-id/",
-              "type_info": {
-                "description": "",
-                "type": "uint8"
-              },
-              "children": [],
-              "name": "cos-id",
-              "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:ttl/",
-              "type_info": {
-                "description": "",
-                "type": "uint8"
-              },
-              "children": [],
-              "name": "ttl",
-              "description": "Time to Live.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:sub-type/",
-              "type_info": {
-                "description": "",
-                "type": "identityref",
-                "base": ["command-sub-type"]
-              },
-              "children": [],
-              "name": "sub-type",
-              "description": "Defines different command types.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:source-mep/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "source-mep",
-              "description": "Source MEP.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
-                  "type_info": {},
-                  "children": [
-                    {
-                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
-                        "type_info": {
-                          "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                          "type": "yang:mac-address"
-                        },
-                        "children": [],
-                        "name": "mac-address",
-                        "description": "MAC Address.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "mac-address",
-                      "description": "MAC Address based MEP Addressing.",
-                      "config": true,
-                      "class": "case",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
-                        "type_info": {
-                          "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                          "type": "inet:ip-address"
-                        },
-                        "children": [],
-                        "name": "ip-address",
-                        "description": "IP Address.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "ip-address",
-                      "description": "IP Address based MEP Addressing.",
-                      "config": true,
-                      "class": "case",
-                      "status": "CURRENT"
-                    }
-                  ],
-                  "name": "mep-address",
-                  "description": "MEP Addressing.",
-                  "config": true,
-                  "class": "choice",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
-                  "type_info": {},
-                  "children": [{
-                    "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
-                    "type_info": {},
-                    "children": [{
-                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
-                      "type_info": {
-                        "description": "",
-                        "type": "int32"
-                      },
-                      "children": [],
-                      "name": "mep-id-int",
-                      "description": "MEP ID\nin integer format.",
-                      "config": true,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    }],
-                    "name": "mep-id-int",
-                    "description": "",
-                    "config": true,
-                    "class": "case",
-                    "status": "CURRENT"
-                  }],
-                  "name": "mep-id",
-                  "description": "MEP ID.",
-                  "config": true,
-                  "class": "choice",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
-                  "type_info": {
-                    "description": "",
-                    "type": "identityref",
-                    "base": ["identifier-format"]
-                  },
-                  "children": [],
-                  "name": "mep-id-format",
-                  "description": "MEP ID format.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }
-              ],
-              "name": "destination-mep",
-              "description": "Destination MEP.",
-              "config": true,
-              "class": "container",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:count/",
-              "type_info": {
-                "default": "3",
-                "description": "Number of continuity-verification messages to be sent.",
-                "type": "co-oam:count"
-              },
-              "children": [],
-              "name": "count",
-              "description": "Number of continuity-verification messages to be sent.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:interval/",
-              "type_info": {
-                "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
-                "type": "co-oam:time-interval"
-              },
-              "children": [],
-              "name": "interval",
-              "description": "Time interval between echo requests.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:continuity-verification/co-oam:input/co-oam:packet-size/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:uint32"
-              },
-              "children": [],
-              "name": "packet-size",
-              "description": "Size of continuity-verification packets, in octets.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "input",
-          "description": "",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:continuity-verification/co-oam:output/",
-          "type_info": {},
-          "children": [{
-            "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/",
-            "type_info": {},
-            "children": [{
-              "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/",
-              "type_info": {},
-              "children": [{
-                "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
-                "type_info": {
-                  "description": "",
-                  "type": "empty"
-                },
-                "children": [],
-                "name": "monitor-null",
-                "description": "There are no monitoring statistics to be defined.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              }],
-              "name": "monitor-null",
-              "description": "This is a placeholder when\nno monitoring statistics are needed.",
-              "config": false,
-              "class": "case",
-              "status": "CURRENT"
-            }],
-            "name": "monitor-stats",
-            "description": "Define the monitor stats.",
-            "config": false,
-            "class": "choice",
-            "status": "CURRENT"
-          }],
-          "name": "output",
-          "description": "",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "continuity-verification",
-      "description": "Generates Connectivity Verification as per Table 4 in RFC 7276.",
-      "class": "rpc",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/co-oam:traceroute/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/co-oam:traceroute/co-oam:input/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:md-name-string/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "md-name-string",
-              "description": "Indicate which MD the defect belongs to.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:md-level/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "md-level",
-              "description": "The Maintenance Domain Level.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:ma-name-string/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "ma-name-string",
-              "description": "Indicate which MA the defect is associated with.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:cos-id/",
-              "type_info": {
-                "description": "",
-                "type": "uint8"
-              },
-              "children": [],
-              "name": "cos-id",
-              "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:ttl/",
-              "type_info": {
-                "description": "",
-                "type": "uint8"
-              },
-              "children": [],
-              "name": "ttl",
-              "description": "Time to Live.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:command-sub-type/",
-              "type_info": {
-                "description": "",
-                "type": "identityref",
-                "base": ["command-sub-type"]
-              },
-              "children": [],
-              "name": "command-sub-type",
-              "description": "Defines different command types.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:source-mep/",
-              "type_info": {
-                "description": "",
-                "type": "co-oam:leafref"
-              },
-              "children": [],
-              "name": "source-mep",
-              "description": "Source MEP.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
-                  "type_info": {},
-                  "children": [
-                    {
-                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
-                        "type_info": {
-                          "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                          "type": "yang:mac-address"
-                        },
-                        "children": [],
-                        "name": "mac-address",
-                        "description": "MAC Address.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "mac-address",
-                      "description": "MAC Address based MEP Addressing.",
-                      "config": true,
-                      "class": "case",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
-                        "type_info": {
-                          "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                          "type": "inet:ip-address"
-                        },
-                        "children": [],
-                        "name": "ip-address",
-                        "description": "IP Address.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "ip-address",
-                      "description": "IP Address based MEP Addressing.",
-                      "config": true,
-                      "class": "case",
-                      "status": "CURRENT"
-                    }
-                  ],
-                  "name": "mep-address",
-                  "description": "MEP Addressing.",
-                  "config": true,
-                  "class": "choice",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
-                  "type_info": {},
-                  "children": [{
-                    "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
-                    "type_info": {},
-                    "children": [{
-                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
-                      "type_info": {
-                        "description": "",
-                        "type": "int32"
-                      },
-                      "children": [],
-                      "name": "mep-id-int",
-                      "description": "MEP ID\nin integer format.",
-                      "config": true,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    }],
-                    "name": "mep-id-int",
-                    "description": "",
-                    "config": true,
-                    "class": "case",
-                    "status": "CURRENT"
-                  }],
-                  "name": "mep-id",
-                  "description": "MEP ID.",
-                  "config": true,
-                  "class": "choice",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
-                  "type_info": {
-                    "description": "",
-                    "type": "identityref",
-                    "base": ["identifier-format"]
-                  },
-                  "children": [],
-                  "name": "mep-id-format",
-                  "description": "MEP ID format.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }
-              ],
-              "name": "destination-mep",
-              "description": "Destination MEP.",
-              "config": true,
-              "class": "container",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:count/",
-              "type_info": {
-                "default": "1",
-                "description": "Number of traceroute probes to send.  In protocols where a\nseparate message is sent at each TTL, this is the number\nof packets to be sent at each TTL.",
-                "type": "co-oam:count"
-              },
-              "children": [],
-              "name": "count",
-              "description": "Number of traceroute probes to send.  In protocols where a\nseparate message is sent at each TTL, this is the number\nof packets to be sent at each TTL.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/co-oam:traceroute/co-oam:input/co-oam:interval/",
-              "type_info": {
-                "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
-                "type": "co-oam:time-interval"
-              },
-              "children": [],
-              "name": "interval",
-              "description": "Time interval between echo requests.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "input",
-          "description": "",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:traceroute/co-oam:output/",
-          "type_info": {},
-          "children": [{
-            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/",
-            "type_info": {},
-            "children": [
-              {
-                "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:response-index/",
-                "type_info": {
-                  "description": "",
-                  "type": "uint8"
-                },
-                "children": [],
-                "name": "response-index",
-                "description": "Arbitrary index for the response.  In protocols that\nguarantee there is only a single response at each TTL,\nthe TTL can be used as the response index.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:ttl/",
-                "type_info": {
-                  "description": "",
-                  "type": "uint8"
-                },
-                "children": [],
-                "name": "ttl",
-                "description": "Time to Live.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/",
-                "type_info": {},
-                "children": [
-                  {
-                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/",
-                    "type_info": {},
-                    "children": [
-                      {
-                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
-                          "type_info": {
-                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                            "type": "yang:mac-address"
-                          },
-                          "children": [],
-                          "name": "mac-address",
-                          "description": "MAC Address.",
-                          "config": false,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "mac-address",
-                        "description": "MAC Address based MEP Addressing.",
-                        "config": false,
-                        "class": "case",
-                        "status": "CURRENT"
-                      },
-                      {
-                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
-                          "type_info": {
-                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                            "type": "inet:ip-address"
-                          },
-                          "children": [],
-                          "name": "ip-address",
-                          "description": "IP Address.",
-                          "config": false,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "ip-address",
-                        "description": "IP Address based MEP Addressing.",
-                        "config": false,
-                        "class": "case",
-                        "status": "CURRENT"
-                      }
-                    ],
-                    "name": "mep-address",
-                    "description": "MEP Addressing.",
-                    "config": false,
-                    "class": "choice",
-                    "status": "CURRENT"
-                  },
-                  {
-                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/",
-                    "type_info": {},
-                    "children": [{
-                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
-                        "type_info": {
-                          "description": "",
-                          "type": "int32"
-                        },
-                        "children": [],
                         "name": "mep-id-int",
-                        "description": "MEP ID\nin integer format.",
-                        "config": false,
-                        "class": "leaf",
+                        "description": "",
+                        "config": true,
+                        "class": "case",
                         "status": "CURRENT"
                       }],
-                      "name": "mep-id-int",
-                      "description": "",
-                      "config": false,
-                      "class": "case",
+                      "name": "mep-id",
+                      "description": "MEP ID.",
+                      "config": true,
+                      "class": "choice",
                       "status": "CURRENT"
-                    }],
-                    "name": "mep-id",
-                    "description": "MEP ID.",
-                    "config": false,
-                    "class": "choice",
-                    "status": "CURRENT"
-                  },
-                  {
-                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id-format/",
-                    "type_info": {
-                      "description": "",
-                      "type": "identityref",
-                      "base": ["identifier-format"]
                     },
-                    "children": [],
-                    "name": "mep-id-format",
-                    "description": "MEP ID format.",
-                    "config": false,
-                    "class": "leaf",
-                    "status": "CURRENT"
-                  }
-                ],
-                "name": "destination-mep",
-                "description": "MEP from which the response has been received",
-                "config": false,
-                "class": "container",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/",
-                "type_info": {},
-                "children": [
-                  {
-                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:interface/",
-                    "type_info": {
-                      "description": "This type is used by data models that need to reference\ninterfaces.",
-                      "type": "if:interface-ref"
-                    },
-                    "children": [],
-                    "name": "interface",
-                    "description": "MIP interface.",
-                    "config": false,
-                    "class": "leaf",
-                    "status": "CURRENT"
-                  },
-                  {
-                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/",
-                    "type_info": {},
-                    "children": [
-                      {
-                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:mac-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:mac-address/co-oam:mac-address/",
-                          "type_info": {
-                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
-                            "type": "yang:mac-address"
-                          },
-                          "children": [],
-                          "name": "mac-address",
-                          "description": "MAC Address of Maintenance Intermediate Point",
-                          "config": false,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "mac-address",
-                        "description": "MAC Address based MIP Addressing.",
-                        "config": false,
-                        "class": "case",
-                        "status": "CURRENT"
+                    {
+                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
+                      "type_info": {
+                        "description": "",
+                        "type": "identityref",
+                        "base": ["identifier-format"]
                       },
-                      {
-                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:ip-address/",
-                        "type_info": {},
-                        "children": [{
-                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:ip-address/co-oam:ip-address/",
-                          "type_info": {
-                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
-                            "type": "inet:ip-address"
-                          },
-                          "children": [],
-                          "name": "ip-address",
-                          "description": "IP Address.",
-                          "config": false,
-                          "class": "leaf",
-                          "status": "CURRENT"
-                        }],
-                        "name": "ip-address",
-                        "description": "IP Address based MIP Addressing.",
-                        "config": false,
-                        "class": "case",
-                        "status": "CURRENT"
-                      }
-                    ],
-                    "name": "mip-address",
-                    "description": "MIP Addressing.",
-                    "config": false,
-                    "class": "choice",
-                    "status": "CURRENT"
-                  }
-                ],
-                "name": "mip",
-                "description": "MIP responding with traceroute",
-                "config": false,
-                "class": "container",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/",
+                      "children": [],
+                      "name": "mep-id-format",
+                      "description": "MEP ID format.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "destination-mep",
+                  "description": "Destination MEP.",
+                  "config": true,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:count/",
+                  "type_info": {
+                    "default": "3",
+                    "description": "Number of continuity-check messages to be sent.",
+                    "type": "co-oam:count"
+                  },
+                  "children": [],
+                  "name": "count",
+                  "description": "Number of continuity-check messages to be sent.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:cc-transmit-interval/",
+                  "type_info": {
+                    "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
+                    "type": "co-oam:time-interval"
+                  },
+                  "children": [],
+                  "name": "cc-transmit-interval",
+                  "description": "Time interval between echo requests.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-check/co-oam:input/co-oam:packet-size/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:uint32"
+                  },
+                  "children": [],
+                  "name": "packet-size",
+                  "description": "Size of continuity-check packets, in octets.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "input",
+              "description": "",
+              "config": true,
+              "class": "container",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:continuity-check/co-oam:output/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/",
                 "type_info": {},
                 "children": [{
-                  "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/co-oam:monitor-null/",
+                  "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/",
                   "type_info": {},
                   "children": [{
-                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
+                    "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
                     "type_info": {
                       "description": "",
                       "type": "empty"
@@ -1767,403 +954,1220 @@
                 "config": false,
                 "class": "choice",
                 "status": "CURRENT"
-              }
-            ],
-            "name": "response",
-            "description": "List of responses.",
-            "config": false,
-            "class": "list",
-            "status": "CURRENT"
-          }],
-          "name": "output",
-          "description": "",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "traceroute",
-      "description": "Generates Traceroute or Path Trace and returns response.\nReferences RFC 7276 for common Toolset name -- for\nMPLS-TP OAM, it's Route Tracing, and for TRILL OAM, it's\nPath Tracing tool.  Starts with TTL of one and increments\nby one at each hop until the destination is reached or TTL\nreaches max value.",
-      "class": "rpc",
-      "status": "CURRENT"
-    }
-  ],
-  "notifications": [
-    {
-      "path": "Absolute{qnames=[(urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam?revision=2019-04-16)defect-condition-notification]}",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/co-oam:defect-condition-notification/co-oam:technology/",
-          "type_info": {
-            "description": "",
-            "type": "identityref",
-            "base": ["technology-types"]
-          },
-          "children": [],
-          "name": "technology",
-          "description": "The technology.",
-          "config": false,
-          "class": "leaf",
+              }],
+              "name": "output",
+              "description": "",
+              "config": false,
+              "class": "container",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "continuity-check",
+          "description": "Generates Continuity Check as per Table 4 of RFC 7276.",
+          "class": "rpc",
           "status": "CURRENT"
         },
         {
-          "path": "/co-oam:defect-condition-notification/co-oam:md-name-string/",
-          "type_info": {
-            "description": "",
-            "type": "co-oam:leafref"
-          },
-          "children": [],
-          "name": "md-name-string",
-          "description": "Indicate which MD the defect belongs to.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-condition-notification/co-oam:ma-name-string/",
-          "type_info": {
-            "description": "",
-            "type": "co-oam:leafref"
-          },
-          "children": [],
-          "name": "ma-name-string",
-          "description": "Indicate which MA the defect is associated with.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-condition-notification/co-oam:mep-name/",
-          "type_info": {
-            "description": "",
-            "type": "co-oam:leafref"
-          },
-          "children": [],
-          "name": "mep-name",
-          "description": "Indicate which MEP is seeing the defect.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-condition-notification/co-oam:defect-type/",
-          "type_info": {
-            "description": "",
-            "type": "identityref",
-            "base": ["defect-types"]
-          },
-          "children": [],
-          "name": "defect-type",
-          "description": "The currently active defects on the specific MEP.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/",
+          "path": "/co-oam:continuity-verification/",
           "type_info": {},
           "children": [
             {
-              "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/",
+              "path": "/co-oam:continuity-verification/co-oam:input/",
               "type_info": {},
-              "children": [{
-                "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/",
-                "type_info": {},
-                "children": [{
-                  "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+              "children": [
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:md-name-string/",
                   "type_info": {
                     "description": "",
-                    "type": "int32"
+                    "type": "co-oam:leafref"
                   },
                   "children": [],
-                  "name": "mep-id-int",
-                  "description": "MEP ID\nin integer format.",
-                  "config": false,
+                  "name": "md-name-string",
+                  "description": "Indicate which MD the defect belongs to.",
+                  "config": true,
                   "class": "leaf",
                   "status": "CURRENT"
-                }],
-                "name": "mep-id-int",
-                "description": "",
-                "config": false,
-                "class": "case",
-                "status": "CURRENT"
-              }],
-              "name": "mep-id",
-              "description": "MEP ID.",
-              "config": false,
-              "class": "choice",
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:md-level/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "md-level",
+                  "description": "The Maintenance Domain Level.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:ma-name-string/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "ma-name-string",
+                  "description": "Indicate which MA the defect is associated with.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:cos-id/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "cos-id",
+                  "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:ttl/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "ttl",
+                  "description": "Time to Live.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:sub-type/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["command-sub-type"]
+                  },
+                  "children": [],
+                  "name": "sub-type",
+                  "description": "Defines different command types.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:source-mep/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "source-mep",
+                  "description": "Source MEP.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mep-address",
+                      "description": "MEP Addressing.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                          "type_info": {
+                            "description": "",
+                            "type": "int32"
+                          },
+                          "children": [],
+                          "name": "mep-id-int",
+                          "description": "MEP ID\nin integer format.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mep-id-int",
+                        "description": "",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id",
+                      "description": "MEP ID.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
+                      "type_info": {
+                        "description": "",
+                        "type": "identityref",
+                        "base": ["identifier-format"]
+                      },
+                      "children": [],
+                      "name": "mep-id-format",
+                      "description": "MEP ID format.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "destination-mep",
+                  "description": "Destination MEP.",
+                  "config": true,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:count/",
+                  "type_info": {
+                    "default": "3",
+                    "description": "Number of continuity-verification messages to be sent.",
+                    "type": "co-oam:count"
+                  },
+                  "children": [],
+                  "name": "count",
+                  "description": "Number of continuity-verification messages to be sent.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:interval/",
+                  "type_info": {
+                    "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
+                    "type": "co-oam:time-interval"
+                  },
+                  "children": [],
+                  "name": "interval",
+                  "description": "Time interval between echo requests.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:continuity-verification/co-oam:input/co-oam:packet-size/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:uint32"
+                  },
+                  "children": [],
+                  "name": "packet-size",
+                  "description": "Size of continuity-verification packets, in octets.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "input",
+              "description": "",
+              "config": true,
+              "class": "container",
               "status": "CURRENT"
             },
             {
-              "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id-format/",
+              "path": "/co-oam:continuity-verification/co-oam:output/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
+                    "type_info": {
+                      "description": "",
+                      "type": "empty"
+                    },
+                    "children": [],
+                    "name": "monitor-null",
+                    "description": "There are no monitoring statistics to be defined.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "monitor-null",
+                  "description": "This is a placeholder when\nno monitoring statistics are needed.",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
+                }],
+                "name": "monitor-stats",
+                "description": "Define the monitor stats.",
+                "config": false,
+                "class": "choice",
+                "status": "CURRENT"
+              }],
+              "name": "output",
+              "description": "",
+              "config": false,
+              "class": "container",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "continuity-verification",
+          "description": "Generates Connectivity Verification as per Table 4 in RFC 7276.",
+          "class": "rpc",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/co-oam:traceroute/",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/co-oam:traceroute/co-oam:input/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:md-name-string/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "md-name-string",
+                  "description": "Indicate which MD the defect belongs to.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:md-level/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "md-level",
+                  "description": "The Maintenance Domain Level.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:ma-name-string/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "ma-name-string",
+                  "description": "Indicate which MA the defect is associated with.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:cos-id/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "cos-id",
+                  "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:ttl/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "ttl",
+                  "description": "Time to Live.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:command-sub-type/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["command-sub-type"]
+                  },
+                  "children": [],
+                  "name": "command-sub-type",
+                  "description": "Defines different command types.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:source-mep/",
+                  "type_info": {
+                    "description": "",
+                    "type": "co-oam:leafref"
+                  },
+                  "children": [],
+                  "name": "source-mep",
+                  "description": "Source MEP.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mep-address",
+                      "description": "MEP Addressing.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                          "type_info": {
+                            "description": "",
+                            "type": "int32"
+                          },
+                          "children": [],
+                          "name": "mep-id-int",
+                          "description": "MEP ID\nin integer format.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mep-id-int",
+                        "description": "",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id",
+                      "description": "MEP ID.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
+                      "type_info": {
+                        "description": "",
+                        "type": "identityref",
+                        "base": ["identifier-format"]
+                      },
+                      "children": [],
+                      "name": "mep-id-format",
+                      "description": "MEP ID format.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "destination-mep",
+                  "description": "Destination MEP.",
+                  "config": true,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:count/",
+                  "type_info": {
+                    "default": "1",
+                    "description": "Number of traceroute probes to send.  In protocols where a\nseparate message is sent at each TTL, this is the number\nof packets to be sent at each TTL.",
+                    "type": "co-oam:count"
+                  },
+                  "children": [],
+                  "name": "count",
+                  "description": "Number of traceroute probes to send.  In protocols where a\nseparate message is sent at each TTL, this is the number\nof packets to be sent at each TTL.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:input/co-oam:interval/",
+                  "type_info": {
+                    "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
+                    "type": "co-oam:time-interval"
+                  },
+                  "children": [],
+                  "name": "interval",
+                  "description": "Time interval between echo requests.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "input",
+              "description": "",
+              "config": true,
+              "class": "container",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:traceroute/co-oam:output/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:traceroute/co-oam:output/co-oam:response/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:response-index/",
+                    "type_info": {
+                      "description": "",
+                      "type": "uint8"
+                    },
+                    "children": [],
+                    "name": "response-index",
+                    "description": "Arbitrary index for the response.  In protocols that\nguarantee there is only a single response at each TTL,\nthe TTL can be used as the response index.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:ttl/",
+                    "type_info": {
+                      "description": "",
+                      "type": "uint8"
+                    },
+                    "children": [],
+                    "name": "ttl",
+                    "description": "Time to Live.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                              "type_info": {
+                                "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                                "type": "yang:mac-address"
+                              },
+                              "children": [],
+                              "name": "mac-address",
+                              "description": "MAC Address.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "mac-address",
+                            "description": "MAC Address based MEP Addressing.",
+                            "config": false,
+                            "class": "case",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                              "type_info": {
+                                "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                                "type": "inet:ip-address"
+                              },
+                              "children": [],
+                              "name": "ip-address",
+                              "description": "IP Address.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "ip-address",
+                            "description": "IP Address based MEP Addressing.",
+                            "config": false,
+                            "class": "case",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "mep-address",
+                        "description": "MEP Addressing.",
+                        "config": false,
+                        "class": "choice",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                            "type_info": {
+                              "description": "",
+                              "type": "int32"
+                            },
+                            "children": [],
+                            "name": "mep-id-int",
+                            "description": "MEP ID\nin integer format.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mep-id-int",
+                          "description": "",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mep-id",
+                        "description": "MEP ID.",
+                        "config": false,
+                        "class": "choice",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id-format/",
+                        "type_info": {
+                          "description": "",
+                          "type": "identityref",
+                          "base": ["identifier-format"]
+                        },
+                        "children": [],
+                        "name": "mep-id-format",
+                        "description": "MEP ID format.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "destination-mep",
+                    "description": "MEP from which the response has been received",
+                    "config": false,
+                    "class": "container",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:interface/",
+                        "type_info": {
+                          "description": "This type is used by data models that need to reference\ninterfaces.",
+                          "type": "if:interface-ref"
+                        },
+                        "children": [],
+                        "name": "interface",
+                        "description": "MIP interface.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:mac-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:mac-address/co-oam:mac-address/",
+                              "type_info": {
+                                "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                                "type": "yang:mac-address"
+                              },
+                              "children": [],
+                              "name": "mac-address",
+                              "description": "MAC Address of Maintenance Intermediate Point",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "mac-address",
+                            "description": "MAC Address based MIP Addressing.",
+                            "config": false,
+                            "class": "case",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:ip-address/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:ip-address/co-oam:ip-address/",
+                              "type_info": {
+                                "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                                "type": "inet:ip-address"
+                              },
+                              "children": [],
+                              "name": "ip-address",
+                              "description": "IP Address.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }],
+                            "name": "ip-address",
+                            "description": "IP Address based MIP Addressing.",
+                            "config": false,
+                            "class": "case",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "mip-address",
+                        "description": "MIP Addressing.",
+                        "config": false,
+                        "class": "choice",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "mip",
+                    "description": "MIP responding with traceroute",
+                    "config": false,
+                    "class": "container",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/co-oam:monitor-null/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
+                        "type_info": {
+                          "description": "",
+                          "type": "empty"
+                        },
+                        "children": [],
+                        "name": "monitor-null",
+                        "description": "There are no monitoring statistics to be defined.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }],
+                      "name": "monitor-null",
+                      "description": "This is a placeholder when\nno monitoring statistics are needed.",
+                      "config": false,
+                      "class": "case",
+                      "status": "CURRENT"
+                    }],
+                    "name": "monitor-stats",
+                    "description": "Define the monitor stats.",
+                    "config": false,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "response",
+                "description": "List of responses.",
+                "config": false,
+                "class": "list",
+                "status": "CURRENT"
+              }],
+              "name": "output",
+              "description": "",
+              "config": false,
+              "class": "container",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "traceroute",
+          "description": "Generates Traceroute or Path Trace and returns response.\nReferences RFC 7276 for common Toolset name -- for\nMPLS-TP OAM, it's Route Tracing, and for TRILL OAM, it's\nPath Tracing tool.  Starts with TTL of one and increments\nby one at each hop until the destination is reached or TTL\nreaches max value.",
+          "class": "rpc",
+          "status": "CURRENT"
+        }
+      ],
+      "notifications": [
+        {
+          "path": "Absolute{qnames=[(urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam?revision=2019-04-16)defect-condition-notification]}",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/co-oam:defect-condition-notification/co-oam:technology/",
               "type_info": {
                 "description": "",
                 "type": "identityref",
-                "base": ["identifier-format"]
+                "base": ["technology-types"]
               },
               "children": [],
-              "name": "mep-id-format",
-              "description": "MEP ID format.",
+              "name": "technology",
+              "description": "The technology.",
               "config": false,
               "class": "leaf",
               "status": "CURRENT"
-            }
-          ],
-          "name": "generating-mepid",
-          "description": "Indicate who is generating the defect (if known). If\nunknown, set it to 0.",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-condition-notification/co-oam:defect/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-null/",
-              "type_info": {},
-              "children": [{
-                "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-null/co-oam:defect-null/",
-                "type_info": {
-                  "description": "",
-                  "type": "empty"
-                },
-                "children": [],
-                "name": "defect-null",
-                "description": "There is no defect to be defined; it will be defined in\na technology-specific model.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              }],
-              "name": "defect-null",
-              "description": "This is a placeholder when no defect status is needed.",
-              "config": false,
-              "class": "case",
-              "status": "CURRENT"
             },
             {
-              "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-code/",
-              "type_info": {},
-              "children": [{
-                "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-code/co-oam:defect-code/",
-                "type_info": {
-                  "description": "",
-                  "type": "int32"
-                },
-                "children": [],
-                "name": "defect-code",
-                "description": "Defect code is integer value specific to a technology.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              }],
-              "name": "defect-code",
-              "description": "This is a placeholder to display defect code.",
-              "config": false,
-              "class": "case",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "defect",
-          "description": "Defect Message choices.",
-          "config": false,
-          "class": "choice",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "defect-condition-notification",
-      "description": "When the defect condition is met, this notification is sent.",
-      "class": "notification",
-      "status": "CURRENT"
-    },
-    {
-      "path": "Absolute{qnames=[(urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam?revision=2019-04-16)defect-cleared-notification]}",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:technology/",
-          "type_info": {
-            "description": "",
-            "type": "identityref",
-            "base": ["technology-types"]
-          },
-          "children": [],
-          "name": "technology",
-          "description": "The technology.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:md-name-string/",
-          "type_info": {
-            "description": "",
-            "type": "co-oam:leafref"
-          },
-          "children": [],
-          "name": "md-name-string",
-          "description": "Indicate which MD the defect belongs to",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:ma-name-string/",
-          "type_info": {
-            "description": "",
-            "type": "co-oam:leafref"
-          },
-          "children": [],
-          "name": "ma-name-string",
-          "description": "Indicate which MA the defect is associated with.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:mep-name/",
-          "type_info": {
-            "description": "",
-            "type": "co-oam:leafref"
-          },
-          "children": [],
-          "name": "mep-name",
-          "description": "Indicate which MEP is seeing the defect.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:defect-type/",
-          "type_info": {
-            "description": "",
-            "type": "identityref",
-            "base": ["defect-types"]
-          },
-          "children": [],
-          "name": "defect-type",
-          "description": "The currently active defects on the specific MEP.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/",
-              "type_info": {},
-              "children": [{
-                "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/",
-                "type_info": {},
-                "children": [{
-                  "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
-                  "type_info": {
-                    "description": "",
-                    "type": "int32"
-                  },
-                  "children": [],
-                  "name": "mep-id-int",
-                  "description": "MEP ID\nin integer format.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }],
-                "name": "mep-id-int",
+              "path": "/co-oam:defect-condition-notification/co-oam:md-name-string/",
+              "type_info": {
                 "description": "",
-                "config": false,
-                "class": "case",
-                "status": "CURRENT"
-              }],
-              "name": "mep-id",
-              "description": "MEP ID.",
+                "type": "co-oam:leafref"
+              },
+              "children": [],
+              "name": "md-name-string",
+              "description": "Indicate which MD the defect belongs to.",
               "config": false,
-              "class": "choice",
+              "class": "leaf",
               "status": "CURRENT"
             },
             {
-              "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id-format/",
+              "path": "/co-oam:defect-condition-notification/co-oam:ma-name-string/",
+              "type_info": {
+                "description": "",
+                "type": "co-oam:leafref"
+              },
+              "children": [],
+              "name": "ma-name-string",
+              "description": "Indicate which MA the defect is associated with.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-condition-notification/co-oam:mep-name/",
+              "type_info": {
+                "description": "",
+                "type": "co-oam:leafref"
+              },
+              "children": [],
+              "name": "mep-name",
+              "description": "Indicate which MEP is seeing the defect.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-condition-notification/co-oam:defect-type/",
               "type_info": {
                 "description": "",
                 "type": "identityref",
-                "base": ["identifier-format"]
+                "base": ["defect-types"]
               },
               "children": [],
-              "name": "mep-id-format",
-              "description": "MEP ID format.",
+              "name": "defect-type",
+              "description": "The currently active defects on the specific MEP.",
               "config": false,
               "class": "leaf",
               "status": "CURRENT"
-            }
-          ],
-          "name": "generating-mepid",
-          "description": "Indicate who is generating the defect (if known). If\nunknown, set it to 0.",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/co-oam:defect-cleared-notification/co-oam:defect/",
-          "type_info": {},
-          "children": [
+            },
             {
-              "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-null/",
+              "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/",
               "type_info": {},
-              "children": [{
-                "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-null/co-oam:defect-null/",
-                "type_info": {
-                  "description": "",
-                  "type": "empty"
+              "children": [
+                {
+                  "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                      "type_info": {
+                        "description": "",
+                        "type": "int32"
+                      },
+                      "children": [],
+                      "name": "mep-id-int",
+                      "description": "MEP ID\nin integer format.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }],
+                    "name": "mep-id-int",
+                    "description": "",
+                    "config": false,
+                    "class": "case",
+                    "status": "CURRENT"
+                  }],
+                  "name": "mep-id",
+                  "description": "MEP ID.",
+                  "config": false,
+                  "class": "choice",
+                  "status": "CURRENT"
                 },
-                "children": [],
-                "name": "defect-null",
-                "description": "There is no defect to be defined; it will be defined in\na technology-specific model.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              }],
-              "name": "defect-null",
-              "description": "This is a placeholder when no defect status is needed.",
+                {
+                  "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id-format/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["identifier-format"]
+                  },
+                  "children": [],
+                  "name": "mep-id-format",
+                  "description": "MEP ID format.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "generating-mepid",
+              "description": "Indicate who is generating the defect (if known). If\nunknown, set it to 0.",
               "config": false,
-              "class": "case",
+              "class": "container",
               "status": "CURRENT"
             },
             {
-              "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-code/",
+              "path": "/co-oam:defect-condition-notification/co-oam:defect/",
               "type_info": {},
-              "children": [{
-                "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-code/co-oam:defect-code/",
-                "type_info": {
-                  "description": "",
-                  "type": "int32"
+              "children": [
+                {
+                  "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-null/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-null/co-oam:defect-null/",
+                    "type_info": {
+                      "description": "",
+                      "type": "empty"
+                    },
+                    "children": [],
+                    "name": "defect-null",
+                    "description": "There is no defect to be defined; it will be defined in\na technology-specific model.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "defect-null",
+                  "description": "This is a placeholder when no defect status is needed.",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
                 },
-                "children": [],
-                "name": "defect-code",
-                "description": "Defect code is integer value specific to a technology.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              }],
-              "name": "defect-code",
-              "description": "This is a placeholder to display defect code.",
+                {
+                  "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-code/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-code/co-oam:defect-code/",
+                    "type_info": {
+                      "description": "",
+                      "type": "int32"
+                    },
+                    "children": [],
+                    "name": "defect-code",
+                    "description": "Defect code is integer value specific to a technology.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "defect-code",
+                  "description": "This is a placeholder to display defect code.",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "defect",
+              "description": "Defect Message choices.",
               "config": false,
-              "class": "case",
+              "class": "choice",
               "status": "CURRENT"
             }
           ],
-          "name": "defect",
-          "description": "Defect Message choices.",
-          "config": false,
-          "class": "choice",
+          "name": "defect-condition-notification",
+          "description": "When the defect condition is met, this notification is sent.",
+          "class": "notification",
+          "status": "CURRENT"
+        },
+        {
+          "path": "Absolute{qnames=[(urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam?revision=2019-04-16)defect-cleared-notification]}",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:technology/",
+              "type_info": {
+                "description": "",
+                "type": "identityref",
+                "base": ["technology-types"]
+              },
+              "children": [],
+              "name": "technology",
+              "description": "The technology.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:md-name-string/",
+              "type_info": {
+                "description": "",
+                "type": "co-oam:leafref"
+              },
+              "children": [],
+              "name": "md-name-string",
+              "description": "Indicate which MD the defect belongs to",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:ma-name-string/",
+              "type_info": {
+                "description": "",
+                "type": "co-oam:leafref"
+              },
+              "children": [],
+              "name": "ma-name-string",
+              "description": "Indicate which MA the defect is associated with.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:mep-name/",
+              "type_info": {
+                "description": "",
+                "type": "co-oam:leafref"
+              },
+              "children": [],
+              "name": "mep-name",
+              "description": "Indicate which MEP is seeing the defect.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:defect-type/",
+              "type_info": {
+                "description": "",
+                "type": "identityref",
+                "base": ["defect-types"]
+              },
+              "children": [],
+              "name": "defect-type",
+              "description": "The currently active defects on the specific MEP.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                      "type_info": {
+                        "description": "",
+                        "type": "int32"
+                      },
+                      "children": [],
+                      "name": "mep-id-int",
+                      "description": "MEP ID\nin integer format.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }],
+                    "name": "mep-id-int",
+                    "description": "",
+                    "config": false,
+                    "class": "case",
+                    "status": "CURRENT"
+                  }],
+                  "name": "mep-id",
+                  "description": "MEP ID.",
+                  "config": false,
+                  "class": "choice",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id-format/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["identifier-format"]
+                  },
+                  "children": [],
+                  "name": "mep-id-format",
+                  "description": "MEP ID format.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "generating-mepid",
+              "description": "Indicate who is generating the defect (if known). If\nunknown, set it to 0.",
+              "config": false,
+              "class": "container",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/co-oam:defect-cleared-notification/co-oam:defect/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-null/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-null/co-oam:defect-null/",
+                    "type_info": {
+                      "description": "",
+                      "type": "empty"
+                    },
+                    "children": [],
+                    "name": "defect-null",
+                    "description": "There is no defect to be defined; it will be defined in\na technology-specific model.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "defect-null",
+                  "description": "This is a placeholder when no defect status is needed.",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-code/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-code/co-oam:defect-code/",
+                    "type_info": {
+                      "description": "",
+                      "type": "int32"
+                    },
+                    "children": [],
+                    "name": "defect-code",
+                    "description": "Defect code is integer value specific to a technology.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "defect-code",
+                  "description": "This is a placeholder to display defect code.",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "defect",
+              "description": "Defect Message choices.",
+              "config": false,
+              "class": "choice",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "defect-cleared-notification",
+          "description": "When the defect is cleared, this notification is sent.",
+          "class": "notification",
           "status": "CURRENT"
         }
-      ],
-      "name": "defect-cleared-notification",
-      "description": "When the defect is cleared, this notification is sent.",
-      "class": "notification",
-      "status": "CURRENT"
+      ]
     }
   ]
 }

--- a/src/test/resources/out/compare/interfaces.json
+++ b/src/test/resources/out/compare/interfaces.json
@@ -1,740 +1,744 @@
 {
-  "children": [
+  "parsed-models": [
     {
-      "path": "/if:interfaces/",
-      "type_info": {},
-      "children": [{
-        "path": "/if:interfaces/if:interface/",
-        "type_info": {},
-        "children": [
-          {
-            "path": "/if:interfaces/if:interface/if:name/",
-            "type_info": {
-              "description": "",
-              "type": "string"
-            },
-            "children": [],
-            "name": "name",
-            "description": "The name of the interface.\n\nA device MAY restrict the allowed values for this leaf,\npossibly depending on the type of the interface.\nFor system-controlled interfaces, this leaf is the\ndevice-specific name of the interface.\n\nIf a client tries to create configuration for a\nsystem-controlled interface that is not present in the\noperational state, the server MAY reject the request if\nthe implementation does not support pre-provisioning of\ninterfaces or if the name refers to an interface that can\nnever exist in the system.  A Network Configuration\nProtocol (NETCONF) server MUST reply with an rpc-error\nwith the error-tag 'invalid-value' in this case.\n\nIf the device supports pre-provisioning of interface\nconfiguration, the 'pre-provisioning' feature is\nadvertised.\n\nIf the device allows arbitrarily named user-controlled\ninterfaces, the 'arbitrary-names' feature is advertised.\n\nWhen a configured user-controlled interface is created by\nthe system, it is instantiated with the same name in the\noperational state.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:description/",
-            "type_info": {
-              "description": "",
-              "type": "string"
-            },
-            "children": [],
-            "name": "description",
-            "description": "A textual description of the interface.\n\nA server implementation MAY map this leaf to the ifAlias\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifAlias.  The definition of\nsuch a mechanism is outside the scope of this document.\n\nSince ifAlias is defined to be stored in non-volatile\nstorage, the MIB implementation MUST map ifAlias to the\nvalue of 'description' in the persistently stored\nconfiguration.",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:type/",
-            "type_info": {
-              "description": "",
-              "type": "identityref",
-              "base": ["interface-type"]
-            },
-            "children": [],
-            "name": "type",
-            "description": "The type of the interface.\n\nWhen an interface entry is created, a server MAY\ninitialize the type leaf with a valid value, e.g., if it\nis possible to derive the type from the name of the\ninterface.\n\nIf a client tries to set the type of an interface to a\nvalue that can never be used by the system, e.g., if the\ntype is not supported or if the type does not match the\nname of the interface, the server MUST reject the request.\nA NETCONF server MUST reply with an rpc-error with the\nerror-tag 'invalid-value' in this case.",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:enabled/",
-            "type_info": {
-              "default": "true",
-              "description": "This leaf contains the configured, desired state of the\ninterface.\n\nSystems that implement the IF-MIB use the value of this\nleaf in the intended configuration to set\nIF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry\nhas been initialized, as described in RFC 2863.\n\nChanges in this leaf in the intended configuration are\nreflected in ifAdminStatus.",
-              "type": "if:enabled"
-            },
-            "children": [],
-            "name": "enabled",
-            "description": "This leaf contains the configured, desired state of the\ninterface.\n\nSystems that implement the IF-MIB use the value of this\nleaf in the intended configuration to set\nIF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry\nhas been initialized, as described in RFC 2863.\n\nChanges in this leaf in the intended configuration are\nreflected in ifAdminStatus.",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:link-up-down-trap-enable/",
-            "type_info": {
-              "description": "",
-              "type": "if:enumeration"
-            },
-            "children": [],
-            "name": "link-up-down-trap-enable",
-            "description": "Controls whether linkUp/linkDown SNMP notifications\nshould be generated for this interface.\n\nIf this node is not configured, the value 'enabled' is\noperationally used by the server for interfaces that do\nnot operate on top of any other interface (i.e., there are\nno 'lower-layer-if' entries), and 'disabled' otherwise.",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:admin-status/",
-            "type_info": {
-              "description": "",
-              "type": "if:enumeration"
-            },
-            "children": [],
-            "name": "admin-status",
-            "description": "The desired state of the interface.\n\nThis leaf has the same read semantics as ifAdminStatus.",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:oper-status/",
-            "type_info": {
-              "description": "",
-              "type": "if:enumeration"
-            },
-            "children": [],
-            "name": "oper-status",
-            "description": "The current operational state of the interface.\n\nThis leaf has the same semantics as ifOperStatus.",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:last-change/",
-            "type_info": {
-              "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
-              "type": "yang:date-and-time"
-            },
-            "children": [],
-            "name": "last-change",
-            "description": "The time the interface entered its current operational\nstate.  If the current state was entered prior to the\nlast re-initialization of the local network management\nsubsystem, then this node is not present.",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:if-index/",
-            "type_info": {
-              "description": "",
-              "type": "if:int32"
-            },
-            "children": [],
-            "name": "if-index",
-            "description": "The ifIndex value for the ifEntry represented by this\ninterface.",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:phys-address/",
-            "type_info": {
-              "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
-              "type": "yang:phys-address"
-            },
-            "children": [],
-            "name": "phys-address",
-            "description": "The interface's address at its protocol sub-layer.  For\nexample, for an 802.x interface, this object normally\ncontains a Media Access Control (MAC) address.  The\ninterface's media-specific modules must define the bit\nand byte ordering and the format of the value of this\nobject.  For interfaces that do not have such an address\n(e.g., a serial line), this node is not present.",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:higher-layer-if/",
-            "type_info": {
-              "description": "This type is used by data models that need to reference\ninterfaces.",
-              "type": "if:interface-ref"
-            },
-            "children": [],
-            "name": "higher-layer-if",
-            "description": "A list of references to interfaces layered on top of this\ninterface.",
-            "config": false,
-            "class": "leaf-list",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:lower-layer-if/",
-            "type_info": {
-              "description": "This type is used by data models that need to reference\ninterfaces.",
-              "type": "if:interface-ref"
-            },
-            "children": [],
-            "name": "lower-layer-if",
-            "description": "A list of references to interfaces layered underneath this\ninterface.",
-            "config": false,
-            "class": "leaf-list",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:speed/",
-            "type_info": {
-              "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
-              "type": "if:speed"
-            },
-            "children": [],
-            "name": "speed",
-            "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/if:interfaces/if:interface/if:statistics/",
+      "children": [
+        {
+          "path": "/if:interfaces/",
+          "type_info": {},
+          "children": [{
+            "path": "/if:interfaces/if:interface/",
             "type_info": {},
             "children": [
               {
-                "path": "/if:interfaces/if:interface/if:statistics/if:discontinuity-time/",
+                "path": "/if:interfaces/if:interface/if:name/",
+                "type_info": {
+                  "description": "",
+                  "type": "string"
+                },
+                "children": [],
+                "name": "name",
+                "description": "The name of the interface.\n\nA device MAY restrict the allowed values for this leaf,\npossibly depending on the type of the interface.\nFor system-controlled interfaces, this leaf is the\ndevice-specific name of the interface.\n\nIf a client tries to create configuration for a\nsystem-controlled interface that is not present in the\noperational state, the server MAY reject the request if\nthe implementation does not support pre-provisioning of\ninterfaces or if the name refers to an interface that can\nnever exist in the system.  A Network Configuration\nProtocol (NETCONF) server MUST reply with an rpc-error\nwith the error-tag 'invalid-value' in this case.\n\nIf the device supports pre-provisioning of interface\nconfiguration, the 'pre-provisioning' feature is\nadvertised.\n\nIf the device allows arbitrarily named user-controlled\ninterfaces, the 'arbitrary-names' feature is advertised.\n\nWhen a configured user-controlled interface is created by\nthe system, it is instantiated with the same name in the\noperational state.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:description/",
+                "type_info": {
+                  "description": "",
+                  "type": "string"
+                },
+                "children": [],
+                "name": "description",
+                "description": "A textual description of the interface.\n\nA server implementation MAY map this leaf to the ifAlias\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifAlias.  The definition of\nsuch a mechanism is outside the scope of this document.\n\nSince ifAlias is defined to be stored in non-volatile\nstorage, the MIB implementation MUST map ifAlias to the\nvalue of 'description' in the persistently stored\nconfiguration.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:type/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["interface-type"]
+                },
+                "children": [],
+                "name": "type",
+                "description": "The type of the interface.\n\nWhen an interface entry is created, a server MAY\ninitialize the type leaf with a valid value, e.g., if it\nis possible to derive the type from the name of the\ninterface.\n\nIf a client tries to set the type of an interface to a\nvalue that can never be used by the system, e.g., if the\ntype is not supported or if the type does not match the\nname of the interface, the server MUST reject the request.\nA NETCONF server MUST reply with an rpc-error with the\nerror-tag 'invalid-value' in this case.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:enabled/",
+                "type_info": {
+                  "default": "true",
+                  "description": "This leaf contains the configured, desired state of the\ninterface.\n\nSystems that implement the IF-MIB use the value of this\nleaf in the intended configuration to set\nIF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry\nhas been initialized, as described in RFC 2863.\n\nChanges in this leaf in the intended configuration are\nreflected in ifAdminStatus.",
+                  "type": "if:enabled"
+                },
+                "children": [],
+                "name": "enabled",
+                "description": "This leaf contains the configured, desired state of the\ninterface.\n\nSystems that implement the IF-MIB use the value of this\nleaf in the intended configuration to set\nIF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry\nhas been initialized, as described in RFC 2863.\n\nChanges in this leaf in the intended configuration are\nreflected in ifAdminStatus.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:link-up-down-trap-enable/",
+                "type_info": {
+                  "description": "",
+                  "type": "if:enumeration"
+                },
+                "children": [],
+                "name": "link-up-down-trap-enable",
+                "description": "Controls whether linkUp/linkDown SNMP notifications\nshould be generated for this interface.\n\nIf this node is not configured, the value 'enabled' is\noperationally used by the server for interfaces that do\nnot operate on top of any other interface (i.e., there are\nno 'lower-layer-if' entries), and 'disabled' otherwise.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:admin-status/",
+                "type_info": {
+                  "description": "",
+                  "type": "if:enumeration"
+                },
+                "children": [],
+                "name": "admin-status",
+                "description": "The desired state of the interface.\n\nThis leaf has the same read semantics as ifAdminStatus.",
+                "config": false,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:oper-status/",
+                "type_info": {
+                  "description": "",
+                  "type": "if:enumeration"
+                },
+                "children": [],
+                "name": "oper-status",
+                "description": "The current operational state of the interface.\n\nThis leaf has the same semantics as ifOperStatus.",
+                "config": false,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:last-change/",
                 "type_info": {
                   "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
                   "type": "yang:date-and-time"
                 },
                 "children": [],
-                "name": "discontinuity-time",
-                "description": "The time on the most recent occasion at which any one or\nmore of this interface's counters suffered a\ndiscontinuity.  If no such discontinuities have occurred\nsince the last re-initialization of the local management\nsubsystem, then this node contains the time the local\nmanagement subsystem re-initialized itself.",
+                "name": "last-change",
+                "description": "The time the interface entered its current operational\nstate.  If the current state was entered prior to the\nlast re-initialization of the local network management\nsubsystem, then this node is not present.",
                 "config": false,
                 "class": "leaf",
                 "status": "CURRENT"
               },
               {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-octets/",
+                "path": "/if:interfaces/if:interface/if:if-index/",
                 "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
+                  "description": "",
+                  "type": "if:int32"
                 },
                 "children": [],
-                "name": "in-octets",
-                "description": "The total number of octets received on the interface,\nincluding framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "name": "if-index",
+                "description": "The ifIndex value for the ifEntry represented by this\ninterface.",
                 "config": false,
                 "class": "leaf",
                 "status": "CURRENT"
               },
               {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-unicast-pkts/",
+                "path": "/if:interfaces/if:interface/if:phys-address/",
                 "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
+                  "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
+                  "type": "yang:phys-address"
                 },
                 "children": [],
-                "name": "in-unicast-pkts",
-                "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were not addressed to a\nmulticast or broadcast address at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "name": "phys-address",
+                "description": "The interface's address at its protocol sub-layer.  For\nexample, for an 802.x interface, this object normally\ncontains a Media Access Control (MAC) address.  The\ninterface's media-specific modules must define the bit\nand byte ordering and the format of the value of this\nobject.  For interfaces that do not have such an address\n(e.g., a serial line), this node is not present.",
                 "config": false,
                 "class": "leaf",
                 "status": "CURRENT"
               },
               {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-broadcast-pkts/",
+                "path": "/if:interfaces/if:interface/if:higher-layer-if/",
                 "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
+                  "description": "This type is used by data models that need to reference\ninterfaces.",
+                  "type": "if:interface-ref"
                 },
                 "children": [],
-                "name": "in-broadcast-pkts",
-                "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a broadcast\naddress at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "name": "higher-layer-if",
+                "description": "A list of references to interfaces layered on top of this\ninterface.",
+                "config": false,
+                "class": "leaf-list",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:lower-layer-if/",
+                "type_info": {
+                  "description": "This type is used by data models that need to reference\ninterfaces.",
+                  "type": "if:interface-ref"
+                },
+                "children": [],
+                "name": "lower-layer-if",
+                "description": "A list of references to interfaces layered underneath this\ninterface.",
+                "config": false,
+                "class": "leaf-list",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/if:interfaces/if:interface/if:speed/",
+                "type_info": {
+                  "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
+                  "type": "if:speed"
+                },
+                "children": [],
+                "name": "speed",
+                "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
                 "config": false,
                 "class": "leaf",
                 "status": "CURRENT"
               },
               {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-multicast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "in-multicast-pkts",
-                "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a multicast\naddress at this sub-layer.  For a MAC-layer protocol,\nthis includes both Group and Functional addresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "path": "/if:interfaces/if:interface/if:statistics/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:discontinuity-time/",
+                    "type_info": {
+                      "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                      "type": "yang:date-and-time"
+                    },
+                    "children": [],
+                    "name": "discontinuity-time",
+                    "description": "The time on the most recent occasion at which any one or\nmore of this interface's counters suffered a\ndiscontinuity.  If no such discontinuities have occurred\nsince the last re-initialization of the local management\nsubsystem, then this node contains the time the local\nmanagement subsystem re-initialized itself.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-octets/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-octets",
+                    "description": "The total number of octets received on the interface,\nincluding framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-unicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-unicast-pkts",
+                    "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were not addressed to a\nmulticast or broadcast address at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-broadcast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-broadcast-pkts",
+                    "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a broadcast\naddress at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-multicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-multicast-pkts",
+                    "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a multicast\naddress at this sub-layer.  For a MAC-layer protocol,\nthis includes both Group and Functional addresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-discards/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "in-discards",
+                    "description": "The number of inbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being deliverable to a higher-layer\nprotocol.  One possible reason for discarding such a\npacket could be to free up buffer space.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-errors/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "in-errors",
+                    "description": "For packet-oriented interfaces, the number of inbound\npackets that contained errors preventing them from being\ndeliverable to a higher-layer protocol.  For character-\noriented or fixed-length interfaces, the number of\ninbound transmission units that contained errors\npreventing them from being deliverable to a higher-layer\nprotocol.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:in-unknown-protos/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "in-unknown-protos",
+                    "description": "For packet-oriented interfaces, the number of packets\nreceived via the interface that were discarded because\nof an unknown or unsupported protocol.  For\ncharacter-oriented or fixed-length interfaces that\nsupport protocol multiplexing, the number of\ntransmission units received via the interface that were\ndiscarded because of an unknown or unsupported protocol.\nFor any interface that does not support protocol\nmultiplexing, this counter is not present.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:out-octets/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-octets",
+                    "description": "The total number of octets transmitted out of the\ninterface, including framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:out-unicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-unicast-pkts",
+                    "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were not addressed\nto a multicast or broadcast address at this sub-layer,\nincluding those that were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:out-broadcast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-broadcast-pkts",
+                    "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nbroadcast address at this sub-layer, including those\nthat were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:out-multicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-multicast-pkts",
+                    "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nmulticast address at this sub-layer, including those\nthat were discarded or not sent.  For a MAC-layer\nprotocol, this includes both Group and Functional\naddresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:out-discards/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "out-discards",
+                    "description": "The number of outbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being transmitted.  One possible reason\nfor discarding such a packet could be to free up buffer\nspace.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/if:interfaces/if:interface/if:statistics/if:out-errors/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "out-errors",
+                    "description": "For packet-oriented interfaces, the number of outbound\npackets that could not be transmitted because of errors.\nFor character-oriented or fixed-length interfaces, the\nnumber of outbound transmission units that could not be\ntransmitted because of errors.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "statistics",
+                "description": "A collection of interface-related statistics objects.",
                 "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-discards/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "in-discards",
-                "description": "The number of inbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being deliverable to a higher-layer\nprotocol.  One possible reason for discarding such a\npacket could be to free up buffer space.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-errors/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "in-errors",
-                "description": "For packet-oriented interfaces, the number of inbound\npackets that contained errors preventing them from being\ndeliverable to a higher-layer protocol.  For character-\noriented or fixed-length interfaces, the number of\ninbound transmission units that contained errors\npreventing them from being deliverable to a higher-layer\nprotocol.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:in-unknown-protos/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "in-unknown-protos",
-                "description": "For packet-oriented interfaces, the number of packets\nreceived via the interface that were discarded because\nof an unknown or unsupported protocol.  For\ncharacter-oriented or fixed-length interfaces that\nsupport protocol multiplexing, the number of\ntransmission units received via the interface that were\ndiscarded because of an unknown or unsupported protocol.\nFor any interface that does not support protocol\nmultiplexing, this counter is not present.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:out-octets/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-octets",
-                "description": "The total number of octets transmitted out of the\ninterface, including framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:out-unicast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-unicast-pkts",
-                "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were not addressed\nto a multicast or broadcast address at this sub-layer,\nincluding those that were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:out-broadcast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-broadcast-pkts",
-                "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nbroadcast address at this sub-layer, including those\nthat were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:out-multicast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-multicast-pkts",
-                "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nmulticast address at this sub-layer, including those\nthat were discarded or not sent.  For a MAC-layer\nprotocol, this includes both Group and Functional\naddresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:out-discards/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "out-discards",
-                "description": "The number of outbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being transmitted.  One possible reason\nfor discarding such a packet could be to free up buffer\nspace.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/if:interfaces/if:interface/if:statistics/if:out-errors/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "out-errors",
-                "description": "For packet-oriented interfaces, the number of outbound\npackets that could not be transmitted because of errors.\nFor character-oriented or fixed-length interfaces, the\nnumber of outbound transmission units that could not be\ntransmitted because of errors.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
+                "class": "container",
                 "status": "CURRENT"
               }
             ],
-            "name": "statistics",
-            "description": "A collection of interface-related statistics objects.",
-            "config": false,
-            "class": "container",
+            "name": "interface",
+            "description": "The list of interfaces on the device.\n\nThe status of an interface is available in this list in the\noperational state.  If the configuration of a\nsystem-controlled interface cannot be used by the system\n(e.g., the interface hardware present does not match the\ninterface type), then the configuration is not applied to\nthe system-controlled interface shown in the operational\nstate.  If the configuration of a user-controlled interface\ncannot be used by the system, the configured interface is\nnot instantiated in the operational state.\n\nSystem-controlled interfaces created by the system are\nalways present in this list in the operational state,\nwhether or not they are configured.",
+            "config": true,
+            "class": "list",
             "status": "CURRENT"
-          }
-        ],
-        "name": "interface",
-        "description": "The list of interfaces on the device.\n\nThe status of an interface is available in this list in the\noperational state.  If the configuration of a\nsystem-controlled interface cannot be used by the system\n(e.g., the interface hardware present does not match the\ninterface type), then the configuration is not applied to\nthe system-controlled interface shown in the operational\nstate.  If the configuration of a user-controlled interface\ncannot be used by the system, the configured interface is\nnot instantiated in the operational state.\n\nSystem-controlled interfaces created by the system are\nalways present in this list in the operational state,\nwhether or not they are configured.",
-        "config": true,
-        "class": "list",
-        "status": "CURRENT"
-      }],
-      "name": "interfaces",
-      "description": "Interface parameters.",
-      "config": true,
-      "class": "container",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/if:interfaces-state/",
-      "type_info": {},
-      "children": [{
-        "path": "/if:interfaces-state/if:interface/",
-        "type_info": {},
-        "children": [
-          {
-            "path": "/if:interfaces-state/if:interface/if:name/",
-            "type_info": {
-              "description": "",
-              "type": "string"
-            },
-            "children": [],
-            "name": "name",
-            "description": "The name of the interface.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:type/",
-            "type_info": {
-              "description": "",
-              "type": "identityref",
-              "base": ["interface-type"]
-            },
-            "children": [],
-            "name": "type",
-            "description": "The type of the interface.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:admin-status/",
-            "type_info": {
-              "description": "",
-              "type": "if:enumeration"
-            },
-            "children": [],
-            "name": "admin-status",
-            "description": "The desired state of the interface.\n\nThis leaf has the same read semantics as ifAdminStatus.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:oper-status/",
-            "type_info": {
-              "description": "",
-              "type": "if:enumeration"
-            },
-            "children": [],
-            "name": "oper-status",
-            "description": "The current operational state of the interface.\n\nThis leaf has the same semantics as ifOperStatus.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:last-change/",
-            "type_info": {
-              "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
-              "type": "yang:date-and-time"
-            },
-            "children": [],
-            "name": "last-change",
-            "description": "The time the interface entered its current operational\nstate.  If the current state was entered prior to the\nlast re-initialization of the local network management\nsubsystem, then this node is not present.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:if-index/",
-            "type_info": {
-              "description": "",
-              "type": "if:int32"
-            },
-            "children": [],
-            "name": "if-index",
-            "description": "The ifIndex value for the ifEntry represented by this\ninterface.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:phys-address/",
-            "type_info": {
-              "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
-              "type": "yang:phys-address"
-            },
-            "children": [],
-            "name": "phys-address",
-            "description": "The interface's address at its protocol sub-layer.  For\nexample, for an 802.x interface, this object normally\ncontains a Media Access Control (MAC) address.  The\ninterface's media-specific modules must define the bit\nand byte ordering and the format of the value of this\nobject.  For interfaces that do not have such an address\n(e.g., a serial line), this node is not present.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:higher-layer-if/",
-            "type_info": {
-              "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
-              "type": "if:interface-state-ref"
-            },
-            "children": [],
-            "name": "higher-layer-if",
-            "description": "A list of references to interfaces layered on top of this\ninterface.",
-            "config": false,
-            "class": "leaf-list",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:lower-layer-if/",
-            "type_info": {
-              "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
-              "type": "if:interface-state-ref"
-            },
-            "children": [],
-            "name": "lower-layer-if",
-            "description": "A list of references to interfaces layered underneath this\ninterface.",
-            "config": false,
-            "class": "leaf-list",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:speed/",
-            "type_info": {
-              "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\n\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
-              "type": "if:speed"
-            },
-            "children": [],
-            "name": "speed",
-            "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\n\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
-            "config": false,
-            "class": "leaf",
-            "status": "DEPRECATED"
-          },
-          {
-            "path": "/if:interfaces-state/if:interface/if:statistics/",
+          }],
+          "name": "interfaces",
+          "description": "Interface parameters.",
+          "config": true,
+          "class": "container",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/if:interfaces-state/",
+          "type_info": {},
+          "children": [{
+            "path": "/if:interfaces-state/if:interface/",
             "type_info": {},
             "children": [
               {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:discontinuity-time/",
+                "path": "/if:interfaces-state/if:interface/if:name/",
+                "type_info": {
+                  "description": "",
+                  "type": "string"
+                },
+                "children": [],
+                "name": "name",
+                "description": "The name of the interface.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.",
+                "config": false,
+                "class": "leaf",
+                "status": "DEPRECATED"
+              },
+              {
+                "path": "/if:interfaces-state/if:interface/if:type/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["interface-type"]
+                },
+                "children": [],
+                "name": "type",
+                "description": "The type of the interface.",
+                "config": false,
+                "class": "leaf",
+                "status": "DEPRECATED"
+              },
+              {
+                "path": "/if:interfaces-state/if:interface/if:admin-status/",
+                "type_info": {
+                  "description": "",
+                  "type": "if:enumeration"
+                },
+                "children": [],
+                "name": "admin-status",
+                "description": "The desired state of the interface.\n\nThis leaf has the same read semantics as ifAdminStatus.",
+                "config": false,
+                "class": "leaf",
+                "status": "DEPRECATED"
+              },
+              {
+                "path": "/if:interfaces-state/if:interface/if:oper-status/",
+                "type_info": {
+                  "description": "",
+                  "type": "if:enumeration"
+                },
+                "children": [],
+                "name": "oper-status",
+                "description": "The current operational state of the interface.\n\nThis leaf has the same semantics as ifOperStatus.",
+                "config": false,
+                "class": "leaf",
+                "status": "DEPRECATED"
+              },
+              {
+                "path": "/if:interfaces-state/if:interface/if:last-change/",
                 "type_info": {
                   "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
                   "type": "yang:date-and-time"
                 },
                 "children": [],
-                "name": "discontinuity-time",
-                "description": "The time on the most recent occasion at which any one or\nmore of this interface's counters suffered a\ndiscontinuity.  If no such discontinuities have occurred\nsince the last re-initialization of the local management\nsubsystem, then this node contains the time the local\nmanagement subsystem re-initialized itself.",
+                "name": "last-change",
+                "description": "The time the interface entered its current operational\nstate.  If the current state was entered prior to the\nlast re-initialization of the local network management\nsubsystem, then this node is not present.",
                 "config": false,
                 "class": "leaf",
                 "status": "DEPRECATED"
               },
               {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-octets/",
+                "path": "/if:interfaces-state/if:interface/if:if-index/",
                 "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
+                  "description": "",
+                  "type": "if:int32"
                 },
                 "children": [],
-                "name": "in-octets",
-                "description": "The total number of octets received on the interface,\nincluding framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "name": "if-index",
+                "description": "The ifIndex value for the ifEntry represented by this\ninterface.",
                 "config": false,
                 "class": "leaf",
                 "status": "DEPRECATED"
               },
               {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-unicast-pkts/",
+                "path": "/if:interfaces-state/if:interface/if:phys-address/",
                 "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
+                  "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
+                  "type": "yang:phys-address"
                 },
                 "children": [],
-                "name": "in-unicast-pkts",
-                "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were not addressed to a\nmulticast or broadcast address at this sub-layer.\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "name": "phys-address",
+                "description": "The interface's address at its protocol sub-layer.  For\nexample, for an 802.x interface, this object normally\ncontains a Media Access Control (MAC) address.  The\ninterface's media-specific modules must define the bit\nand byte ordering and the format of the value of this\nobject.  For interfaces that do not have such an address\n(e.g., a serial line), this node is not present.",
                 "config": false,
                 "class": "leaf",
                 "status": "DEPRECATED"
               },
               {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-broadcast-pkts/",
+                "path": "/if:interfaces-state/if:interface/if:higher-layer-if/",
                 "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
+                  "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
+                  "type": "if:interface-state-ref"
                 },
                 "children": [],
-                "name": "in-broadcast-pkts",
-                "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a broadcast\naddress at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "name": "higher-layer-if",
+                "description": "A list of references to interfaces layered on top of this\ninterface.",
+                "config": false,
+                "class": "leaf-list",
+                "status": "DEPRECATED"
+              },
+              {
+                "path": "/if:interfaces-state/if:interface/if:lower-layer-if/",
+                "type_info": {
+                  "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
+                  "type": "if:interface-state-ref"
+                },
+                "children": [],
+                "name": "lower-layer-if",
+                "description": "A list of references to interfaces layered underneath this\ninterface.",
+                "config": false,
+                "class": "leaf-list",
+                "status": "DEPRECATED"
+              },
+              {
+                "path": "/if:interfaces-state/if:interface/if:speed/",
+                "type_info": {
+                  "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\n\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
+                  "type": "if:speed"
+                },
+                "children": [],
+                "name": "speed",
+                "description": "An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\n\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.",
                 "config": false,
                 "class": "leaf",
                 "status": "DEPRECATED"
               },
               {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-multicast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "in-multicast-pkts",
-                "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a multicast\naddress at this sub-layer.  For a MAC-layer protocol,\nthis includes both Group and Functional addresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                "path": "/if:interfaces-state/if:interface/if:statistics/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:discontinuity-time/",
+                    "type_info": {
+                      "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                      "type": "yang:date-and-time"
+                    },
+                    "children": [],
+                    "name": "discontinuity-time",
+                    "description": "The time on the most recent occasion at which any one or\nmore of this interface's counters suffered a\ndiscontinuity.  If no such discontinuities have occurred\nsince the last re-initialization of the local management\nsubsystem, then this node contains the time the local\nmanagement subsystem re-initialized itself.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-octets/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-octets",
+                    "description": "The total number of octets received on the interface,\nincluding framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-unicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-unicast-pkts",
+                    "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were not addressed to a\nmulticast or broadcast address at this sub-layer.\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-broadcast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-broadcast-pkts",
+                    "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a broadcast\naddress at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-multicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "in-multicast-pkts",
+                    "description": "The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a multicast\naddress at this sub-layer.  For a MAC-layer protocol,\nthis includes both Group and Functional addresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-discards/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "in-discards",
+                    "description": "The number of inbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being deliverable to a higher-layer\nprotocol.  One possible reason for discarding such a\npacket could be to free up buffer space.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-errors/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "in-errors",
+                    "description": "For packet-oriented interfaces, the number of inbound\npackets that contained errors preventing them from being\ndeliverable to a higher-layer protocol.  For character-\noriented or fixed-length interfaces, the number of\ninbound transmission units that contained errors\npreventing them from being deliverable to a higher-layer\nprotocol.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:in-unknown-protos/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "in-unknown-protos",
+                    "description": "For packet-oriented interfaces, the number of packets\nreceived via the interface that were discarded because\nof an unknown or unsupported protocol.  For\ncharacter-oriented or fixed-length interfaces that\nsupport protocol multiplexing, the number of\ntransmission units received via the interface that were\ndiscarded because of an unknown or unsupported protocol.\nFor any interface that does not support protocol\nmultiplexing, this counter is not present.\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:out-octets/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-octets",
+                    "description": "The total number of octets transmitted out of the\ninterface, including framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:out-unicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-unicast-pkts",
+                    "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were not addressed\nto a multicast or broadcast address at this sub-layer,\nincluding those that were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:out-broadcast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-broadcast-pkts",
+                    "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nbroadcast address at this sub-layer, including those\nthat were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:out-multicast-pkts/",
+                    "type_info": {
+                      "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
+                      "type": "yang:counter64"
+                    },
+                    "children": [],
+                    "name": "out-multicast-pkts",
+                    "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nmulticast address at this sub-layer, including those\nthat were discarded or not sent.  For a MAC-layer\nprotocol, this includes both Group and Functional\naddresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:out-discards/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "out-discards",
+                    "description": "The number of outbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being transmitted.  One possible reason\nfor discarding such a packet could be to free up buffer\nspace.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  },
+                  {
+                    "path": "/if:interfaces-state/if:interface/if:statistics/if:out-errors/",
+                    "type_info": {
+                      "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
+                      "type": "yang:counter32"
+                    },
+                    "children": [],
+                    "name": "out-errors",
+                    "description": "For packet-oriented interfaces, the number of outbound\npackets that could not be transmitted because of errors.\nFor character-oriented or fixed-length interfaces, the\nnumber of outbound transmission units that could not be\ntransmitted because of errors.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "DEPRECATED"
+                  }
+                ],
+                "name": "statistics",
+                "description": "A collection of interface-related statistics objects.",
                 "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-discards/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "in-discards",
-                "description": "The number of inbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being deliverable to a higher-layer\nprotocol.  One possible reason for discarding such a\npacket could be to free up buffer space.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-errors/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "in-errors",
-                "description": "For packet-oriented interfaces, the number of inbound\npackets that contained errors preventing them from being\ndeliverable to a higher-layer protocol.  For character-\noriented or fixed-length interfaces, the number of\ninbound transmission units that contained errors\npreventing them from being deliverable to a higher-layer\nprotocol.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:in-unknown-protos/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "in-unknown-protos",
-                "description": "For packet-oriented interfaces, the number of packets\nreceived via the interface that were discarded because\nof an unknown or unsupported protocol.  For\ncharacter-oriented or fixed-length interfaces that\nsupport protocol multiplexing, the number of\ntransmission units received via the interface that were\ndiscarded because of an unknown or unsupported protocol.\nFor any interface that does not support protocol\nmultiplexing, this counter is not present.\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:out-octets/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-octets",
-                "description": "The total number of octets transmitted out of the\ninterface, including framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:out-unicast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-unicast-pkts",
-                "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were not addressed\nto a multicast or broadcast address at this sub-layer,\nincluding those that were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:out-broadcast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-broadcast-pkts",
-                "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nbroadcast address at this sub-layer, including those\nthat were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:out-multicast-pkts/",
-                "type_info": {
-                  "description": "The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.",
-                  "type": "yang:counter64"
-                },
-                "children": [],
-                "name": "out-multicast-pkts",
-                "description": "The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nmulticast address at this sub-layer, including those\nthat were discarded or not sent.  For a MAC-layer\nprotocol, this includes both Group and Functional\naddresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:out-discards/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "out-discards",
-                "description": "The number of outbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being transmitted.  One possible reason\nfor discarding such a packet could be to free up buffer\nspace.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
-                "status": "DEPRECATED"
-              },
-              {
-                "path": "/if:interfaces-state/if:interface/if:statistics/if:out-errors/",
-                "type_info": {
-                  "description": "The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.",
-                  "type": "yang:counter32"
-                },
-                "children": [],
-                "name": "out-errors",
-                "description": "For packet-oriented interfaces, the number of outbound\npackets that could not be transmitted because of errors.\nFor character-oriented or fixed-length interfaces, the\nnumber of outbound transmission units that could not be\ntransmitted because of errors.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.",
-                "config": false,
-                "class": "leaf",
+                "class": "container",
                 "status": "DEPRECATED"
               }
             ],
-            "name": "statistics",
-            "description": "A collection of interface-related statistics objects.",
+            "name": "interface",
+            "description": "The list of interfaces on the device.\n\nSystem-controlled interfaces created by the system are\nalways present in this list, whether or not they are\nconfigured.",
             "config": false,
-            "class": "container",
+            "class": "list",
             "status": "DEPRECATED"
-          }
-        ],
-        "name": "interface",
-        "description": "The list of interfaces on the device.\n\nSystem-controlled interfaces created by the system are\nalways present in this list, whether or not they are\nconfigured.",
-        "config": false,
-        "class": "list",
-        "status": "DEPRECATED"
-      }],
-      "name": "interfaces-state",
-      "description": "Data nodes for the operational state of interfaces.",
-      "config": false,
-      "class": "container",
-      "status": "DEPRECATED"
+          }],
+          "name": "interfaces-state",
+          "description": "Data nodes for the operational state of interfaces.",
+          "config": false,
+          "class": "container",
+          "status": "DEPRECATED"
+        }
+      ],
+      "module": {
+        "prefix": "if",
+        "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:netmod@ietf.org>\n\nEditor:   Martin Bjorklund\n          <mailto:mbj@tail-f.com>",
+        "name": "ietf-interfaces",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-interfaces",
+        "description": "This module contains a collection of YANG definitions for\nmanaging network interfaces.\n\nCopyright (c) 2018 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8343; see\nthe RFC itself for full legal notices.",
+        "revision": "2018-02-20"
+      }
     }
-  ],
-  "module": {
-    "prefix": "if",
-    "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:netmod@ietf.org>\n\nEditor:   Martin Bjorklund\n          <mailto:mbj@tail-f.com>",
-    "name": "ietf-interfaces",
-    "namespace": "urn:ietf:params:xml:ns:yang:ietf-interfaces",
-    "description": "This module contains a collection of YANG definitions for\nmanaging network interfaces.\n\nCopyright (c) 2018 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8343; see\nthe RFC itself for full legal notices.",
-    "revision": "2018-02-20"
-  }
+  ]
 }

--- a/src/test/resources/out/compare/ip.json
+++ b/src/test/resources/out/compare/ip.json
@@ -1,854 +1,858 @@
 {
-  "module": {
-    "prefix": "ip",
-    "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:netmod@ietf.org>\n\nEditor:   Martin Bjorklund\n          <mailto:mbj@tail-f.com>",
-    "name": "ietf-ip",
-    "namespace": "urn:ietf:params:xml:ns:yang:ietf-ip",
-    "description": "This module contains a collection of YANG definitions for\nmanaging IP implementations.\n\nCopyright (c) 2018 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8344; see\nthe RFC itself for full legal notices.",
-    "revision": "2018-02-22"
-  },
-  "augments": [
+  "parsed-models": [
     {
-      "path": "/if:interfaces/if:interface/",
-      "children": [
+      "module": {
+        "prefix": "ip",
+        "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:netmod@ietf.org>\n\nEditor:   Martin Bjorklund\n          <mailto:mbj@tail-f.com>",
+        "name": "ietf-ip",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-ip",
+        "description": "This module contains a collection of YANG definitions for\nmanaging IP implementations.\n\nCopyright (c) 2018 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8344; see\nthe RFC itself for full legal notices.",
+        "revision": "2018-02-22"
+      },
+      "augments": [
         {
-          "path": "/if:interfaces/if:interface/ip:ipv4/",
-          "type_info": {},
+          "path": "/if:interfaces/if:interface/",
           "children": [
             {
-              "path": "/if:interfaces/if:interface/ip:ipv4/ip:enabled/",
-              "type_info": {
-                "default": "true",
-                "description": "Controls whether IPv4 is enabled or disabled on this\ninterface.  When IPv4 is enabled, this interface is\nconnected to an IPv4 stack, and the interface can send\nand receive IPv4 packets.",
-                "type": "ip:enabled"
-              },
-              "children": [],
-              "name": "enabled",
-              "description": "Controls whether IPv4 is enabled or disabled on this\ninterface.  When IPv4 is enabled, this interface is\nconnected to an IPv4 stack, and the interface can send\nand receive IPv4 packets.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv4/ip:forwarding/",
-              "type_info": {
-                "default": "false",
-                "description": "Controls IPv4 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv4 routers\nforward datagrams.  IPv4 hosts do not (except those\nsource-routed via the host).",
-                "type": "ip:forwarding"
-              },
-              "children": [],
-              "name": "forwarding",
-              "description": "Controls IPv4 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv4 routers\nforward datagrams.  IPv4 hosts do not (except those\nsource-routed via the host).",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv4/ip:mtu/",
-              "type_info": {
-                "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
-                "type": "ip:mtu"
-              },
-              "children": [],
-              "name": "mtu",
-              "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/",
+              "path": "/if:interfaces/if:interface/ip:ipv4/",
               "type_info": {},
               "children": [
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:ip/",
+                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:enabled/",
                   "type_info": {
-                    "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv4-address-no-zone"
+                    "default": "true",
+                    "description": "Controls whether IPv4 is enabled or disabled on this\ninterface.  When IPv4 is enabled, this interface is\nconnected to an IPv4 stack, and the interface can send\nand receive IPv4 packets.",
+                    "type": "ip:enabled"
                   },
                   "children": [],
-                  "name": "ip",
-                  "description": "The IPv4 address on the interface.",
+                  "name": "enabled",
+                  "description": "Controls whether IPv4 is enabled or disabled on this\ninterface.  When IPv4 is enabled, this interface is\nconnected to an IPv4 stack, and the interface can send\nand receive IPv4 packets.",
                   "config": true,
                   "class": "leaf",
                   "status": "CURRENT"
                 },
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/",
+                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:forwarding/",
+                  "type_info": {
+                    "default": "false",
+                    "description": "Controls IPv4 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv4 routers\nforward datagrams.  IPv4 hosts do not (except those\nsource-routed via the host).",
+                    "type": "ip:forwarding"
+                  },
+                  "children": [],
+                  "name": "forwarding",
+                  "description": "Controls IPv4 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv4 routers\nforward datagrams.  IPv4 hosts do not (except those\nsource-routed via the host).",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:mtu/",
+                  "type_info": {
+                    "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
+                    "type": "ip:mtu"
+                  },
+                  "children": [],
+                  "name": "mtu",
+                  "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/",
                   "type_info": {},
                   "children": [
                     {
-                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/ip:prefix-length/",
-                        "type_info": {
-                          "description": "",
-                          "type": "ip:uint8"
-                        },
-                        "children": [],
-                        "name": "prefix-length",
-                        "description": "The length of the subnet prefix.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "prefix-length",
-                      "description": "",
+                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv4-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv4 address on the interface.",
                       "config": true,
-                      "class": "case",
+                      "class": "leaf",
                       "status": "CURRENT"
                     },
                     {
-                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/",
+                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/",
                       "type_info": {},
-                      "children": [{
-                        "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/ip:netmask/",
-                        "type_info": {
-                          "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
-                          "type": "yang:dotted-quad"
+                      "children": [
+                        {
+                          "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/ip:prefix-length/",
+                            "type_info": {
+                              "description": "",
+                              "type": "ip:uint8"
+                            },
+                            "children": [],
+                            "name": "prefix-length",
+                            "description": "The length of the subnet prefix.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "prefix-length",
+                          "description": "",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
                         },
-                        "children": [],
-                        "name": "netmask",
-                        "description": "The subnet specified as a netmask.",
-                        "config": true,
-                        "class": "leaf",
-                        "status": "CURRENT"
-                      }],
-                      "name": "netmask",
-                      "description": "",
+                        {
+                          "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/ip:netmask/",
+                            "type_info": {
+                              "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
+                              "type": "yang:dotted-quad"
+                            },
+                            "children": [],
+                            "name": "netmask",
+                            "description": "The subnet specified as a netmask.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "netmask",
+                          "description": "",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "subnet",
+                      "description": "The subnet can be specified as a prefix length or,\nif the server supports non-contiguous netmasks, as\na netmask.",
                       "config": true,
-                      "class": "case",
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of an address.",
+                        "type": "ip:ip-address-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this address.",
+                      "config": false,
+                      "class": "leaf",
                       "status": "CURRENT"
                     }
                   ],
-                  "name": "subnet",
-                  "description": "The subnet can be specified as a prefix length or,\nif the server supports non-contiguous netmasks, as\na netmask.",
+                  "name": "address",
+                  "description": "The list of IPv4 addresses on the interface.",
                   "config": true,
-                  "class": "choice",
+                  "class": "list",
                   "status": "CURRENT"
                 },
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:address/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of an address.",
-                    "type": "ip:ip-address-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this address.",
-                  "config": false,
-                  "class": "leaf",
+                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv4-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv4 address of the neighbor node.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/ip:link-layer-address/",
+                      "type_info": {
+                        "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
+                        "type": "yang:phys-address"
+                      },
+                      "children": [],
+                      "name": "link-layer-address",
+                      "description": "The link-layer address of the neighbor node.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of a neighbor entry.",
+                        "type": "ip:neighbor-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this neighbor entry.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "neighbor",
+                  "description": "A list of mappings from IPv4 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the ARP Cache.\n\nIn the operational state, this list represents the ARP\nCache.",
+                  "config": true,
+                  "class": "list",
                   "status": "CURRENT"
                 }
               ],
-              "name": "address",
-              "description": "The list of IPv4 addresses on the interface.",
+              "name": "ipv4",
+              "description": "Parameters for the IPv4 address family.",
               "config": true,
-              "class": "list",
+              "class": "container",
               "status": "CURRENT"
             },
             {
-              "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/",
+              "path": "/if:interfaces/if:interface/ip:ipv6/",
               "type_info": {},
               "children": [
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/ip:ip/",
-                  "type_info": {
-                    "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv4-address-no-zone"
-                  },
-                  "children": [],
-                  "name": "ip",
-                  "description": "The IPv4 address of the neighbor node.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/ip:link-layer-address/",
-                  "type_info": {
-                    "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
-                    "type": "yang:phys-address"
-                  },
-                  "children": [],
-                  "name": "link-layer-address",
-                  "description": "The link-layer address of the neighbor node.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv4/ip:neighbor/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of a neighbor entry.",
-                    "type": "ip:neighbor-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this neighbor entry.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }
-              ],
-              "name": "neighbor",
-              "description": "A list of mappings from IPv4 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the ARP Cache.\n\nIn the operational state, this list represents the ARP\nCache.",
-              "config": true,
-              "class": "list",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "ipv4",
-          "description": "Parameters for the IPv4 address family.",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/if:interfaces/if:interface/ip:ipv6/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:enabled/",
-              "type_info": {
-                "default": "true",
-                "description": "Controls whether IPv6 is enabled or disabled on this\ninterface.  When IPv6 is enabled, this interface is\nconnected to an IPv6 stack, and the interface can send\nand receive IPv6 packets.",
-                "type": "ip:enabled"
-              },
-              "children": [],
-              "name": "enabled",
-              "description": "Controls whether IPv6 is enabled or disabled on this\ninterface.  When IPv6 is enabled, this interface is\nconnected to an IPv6 stack, and the interface can send\nand receive IPv6 packets.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:forwarding/",
-              "type_info": {
-                "default": "false",
-                "description": "Controls IPv6 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv6 routers\nforward datagrams.  IPv6 hosts do not (except those\nsource-routed via the host).",
-                "type": "ip:forwarding"
-              },
-              "children": [],
-              "name": "forwarding",
-              "description": "Controls IPv6 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv6 routers\nforward datagrams.  IPv6 hosts do not (except those\nsource-routed via the host).",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:mtu/",
-              "type_info": {
-                "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
-                "type": "ip:mtu"
-              },
-              "children": [],
-              "name": "mtu",
-              "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:ip/",
-                  "type_info": {
-                    "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv6-address-no-zone"
-                  },
-                  "children": [],
-                  "name": "ip",
-                  "description": "The IPv6 address on the interface.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:prefix-length/",
-                  "type_info": {
-                    "description": "",
-                    "type": "ip:uint8"
-                  },
-                  "children": [],
-                  "name": "prefix-length",
-                  "description": "The length of the subnet prefix.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of an address.",
-                    "type": "ip:ip-address-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this address.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:status/",
-                  "type_info": {
-                    "description": "",
-                    "type": "ip:enumeration"
-                  },
-                  "children": [],
-                  "name": "status",
-                  "description": "The status of an address.  Most of the states correspond\nto states from the IPv6 Stateless Address\nAutoconfiguration protocol.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }
-              ],
-              "name": "address",
-              "description": "The list of IPv6 addresses on the interface.",
-              "config": true,
-              "class": "list",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:ip/",
-                  "type_info": {
-                    "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv6-address-no-zone"
-                  },
-                  "children": [],
-                  "name": "ip",
-                  "description": "The IPv6 address of the neighbor node.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:link-layer-address/",
-                  "type_info": {
-                    "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
-                    "type": "yang:phys-address"
-                  },
-                  "children": [],
-                  "name": "link-layer-address",
-                  "description": "The link-layer address of the neighbor node.\n\nIn the operational state, if the neighbor's 'state' leaf\nis 'incomplete', this leaf is not instantiated.",
-                  "config": true,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of a neighbor entry.",
-                    "type": "ip:neighbor-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this neighbor entry.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:is-router/",
-                  "type_info": {
-                    "description": "",
-                    "type": "empty"
-                  },
-                  "children": [],
-                  "name": "is-router",
-                  "description": "Indicates that the neighbor node acts as a router.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                },
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:state/",
-                  "type_info": {
-                    "description": "",
-                    "type": "ip:enumeration"
-                  },
-                  "children": [],
-                  "name": "state",
-                  "description": "The Neighbor Unreachability Detection state of this\nentry.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "CURRENT"
-                }
-              ],
-              "name": "neighbor",
-              "description": "A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the Neighbor Cache.\n\nIn the operational state, this list represents the\nNeighbor Cache.",
-              "config": true,
-              "class": "list",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:dup-addr-detect-transmits/",
-              "type_info": {
-                "default": "1",
-                "description": "The number of consecutive Neighbor Solicitation messages\nsent while performing Duplicate Address Detection on a\ntentative address.  A value of zero indicates that\nDuplicate Address Detection is not performed on\ntentative addresses.  A value of one indicates a single\ntransmission with no follow-up retransmissions.",
-                "type": "ip:dup-addr-detect-transmits"
-              },
-              "children": [],
-              "name": "dup-addr-detect-transmits",
-              "description": "The number of consecutive Neighbor Solicitation messages\nsent while performing Duplicate Address Detection on a\ntentative address.  A value of zero indicates that\nDuplicate Address Detection is not performed on\ntentative addresses.  A value of one indicates a single\ntransmission with no follow-up retransmissions.",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:create-global-addresses/",
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:enabled/",
                   "type_info": {
                     "default": "true",
-                    "description": "If enabled, the host creates global addresses as\ndescribed in RFC 4862.",
-                    "type": "ip:create-global-addresses"
+                    "description": "Controls whether IPv6 is enabled or disabled on this\ninterface.  When IPv6 is enabled, this interface is\nconnected to an IPv6 stack, and the interface can send\nand receive IPv6 packets.",
+                    "type": "ip:enabled"
                   },
                   "children": [],
-                  "name": "create-global-addresses",
-                  "description": "If enabled, the host creates global addresses as\ndescribed in RFC 4862.",
+                  "name": "enabled",
+                  "description": "Controls whether IPv6 is enabled or disabled on this\ninterface.  When IPv6 is enabled, this interface is\nconnected to an IPv6 stack, and the interface can send\nand receive IPv6 packets.",
                   "config": true,
                   "class": "leaf",
                   "status": "CURRENT"
                 },
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:create-temporary-addresses/",
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:forwarding/",
                   "type_info": {
                     "default": "false",
-                    "description": "If enabled, the host creates temporary addresses as\ndescribed in RFC 4941.",
-                    "type": "ip:create-temporary-addresses"
+                    "description": "Controls IPv6 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv6 routers\nforward datagrams.  IPv6 hosts do not (except those\nsource-routed via the host).",
+                    "type": "ip:forwarding"
                   },
                   "children": [],
-                  "name": "create-temporary-addresses",
-                  "description": "If enabled, the host creates temporary addresses as\ndescribed in RFC 4941.",
+                  "name": "forwarding",
+                  "description": "Controls IPv6 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv6 routers\nforward datagrams.  IPv6 hosts do not (except those\nsource-routed via the host).",
                   "config": true,
                   "class": "leaf",
                   "status": "CURRENT"
                 },
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:temporary-valid-lifetime/",
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:mtu/",
                   "type_info": {
-                    "default": "604800",
-                    "description": "The time period during which the temporary address\nis valid.",
-                    "type": "ip:temporary-valid-lifetime"
+                    "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
+                    "type": "ip:mtu"
                   },
                   "children": [],
-                  "name": "temporary-valid-lifetime",
-                  "description": "The time period during which the temporary address\nis valid.",
+                  "name": "mtu",
+                  "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.",
                   "config": true,
                   "class": "leaf",
                   "status": "CURRENT"
                 },
                 {
-                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:temporary-preferred-lifetime/",
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv6-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv6 address on the interface.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:prefix-length/",
+                      "type_info": {
+                        "description": "",
+                        "type": "ip:uint8"
+                      },
+                      "children": [],
+                      "name": "prefix-length",
+                      "description": "The length of the subnet prefix.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of an address.",
+                        "type": "ip:ip-address-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this address.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:address/ip:status/",
+                      "type_info": {
+                        "description": "",
+                        "type": "ip:enumeration"
+                      },
+                      "children": [],
+                      "name": "status",
+                      "description": "The status of an address.  Most of the states correspond\nto states from the IPv6 Stateless Address\nAutoconfiguration protocol.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "address",
+                  "description": "The list of IPv6 addresses on the interface.",
+                  "config": true,
+                  "class": "list",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv6-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv6 address of the neighbor node.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:link-layer-address/",
+                      "type_info": {
+                        "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
+                        "type": "yang:phys-address"
+                      },
+                      "children": [],
+                      "name": "link-layer-address",
+                      "description": "The link-layer address of the neighbor node.\n\nIn the operational state, if the neighbor's 'state' leaf\nis 'incomplete', this leaf is not instantiated.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of a neighbor entry.",
+                        "type": "ip:neighbor-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this neighbor entry.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:is-router/",
+                      "type_info": {
+                        "description": "",
+                        "type": "empty"
+                      },
+                      "children": [],
+                      "name": "is-router",
+                      "description": "Indicates that the neighbor node acts as a router.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:neighbor/ip:state/",
+                      "type_info": {
+                        "description": "",
+                        "type": "ip:enumeration"
+                      },
+                      "children": [],
+                      "name": "state",
+                      "description": "The Neighbor Unreachability Detection state of this\nentry.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "neighbor",
+                  "description": "A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the Neighbor Cache.\n\nIn the operational state, this list represents the\nNeighbor Cache.",
+                  "config": true,
+                  "class": "list",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:dup-addr-detect-transmits/",
                   "type_info": {
-                    "default": "86400",
-                    "description": "The time period during which the temporary address is\npreferred.",
-                    "type": "ip:temporary-preferred-lifetime"
+                    "default": "1",
+                    "description": "The number of consecutive Neighbor Solicitation messages\nsent while performing Duplicate Address Detection on a\ntentative address.  A value of zero indicates that\nDuplicate Address Detection is not performed on\ntentative addresses.  A value of one indicates a single\ntransmission with no follow-up retransmissions.",
+                    "type": "ip:dup-addr-detect-transmits"
                   },
                   "children": [],
-                  "name": "temporary-preferred-lifetime",
-                  "description": "The time period during which the temporary address is\npreferred.",
+                  "name": "dup-addr-detect-transmits",
+                  "description": "The number of consecutive Neighbor Solicitation messages\nsent while performing Duplicate Address Detection on a\ntentative address.  A value of zero indicates that\nDuplicate Address Detection is not performed on\ntentative addresses.  A value of one indicates a single\ntransmission with no follow-up retransmissions.",
                   "config": true,
                   "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:create-global-addresses/",
+                      "type_info": {
+                        "default": "true",
+                        "description": "If enabled, the host creates global addresses as\ndescribed in RFC 4862.",
+                        "type": "ip:create-global-addresses"
+                      },
+                      "children": [],
+                      "name": "create-global-addresses",
+                      "description": "If enabled, the host creates global addresses as\ndescribed in RFC 4862.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:create-temporary-addresses/",
+                      "type_info": {
+                        "default": "false",
+                        "description": "If enabled, the host creates temporary addresses as\ndescribed in RFC 4941.",
+                        "type": "ip:create-temporary-addresses"
+                      },
+                      "children": [],
+                      "name": "create-temporary-addresses",
+                      "description": "If enabled, the host creates temporary addresses as\ndescribed in RFC 4941.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:temporary-valid-lifetime/",
+                      "type_info": {
+                        "default": "604800",
+                        "description": "The time period during which the temporary address\nis valid.",
+                        "type": "ip:temporary-valid-lifetime"
+                      },
+                      "children": [],
+                      "name": "temporary-valid-lifetime",
+                      "description": "The time period during which the temporary address\nis valid.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/if:interfaces/if:interface/ip:ipv6/ip:autoconf/ip:temporary-preferred-lifetime/",
+                      "type_info": {
+                        "default": "86400",
+                        "description": "The time period during which the temporary address is\npreferred.",
+                        "type": "ip:temporary-preferred-lifetime"
+                      },
+                      "children": [],
+                      "name": "temporary-preferred-lifetime",
+                      "description": "The time period during which the temporary address is\npreferred.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "autoconf",
+                  "description": "Parameters to control the autoconfiguration of IPv6\naddresses, as described in RFC 4862.",
+                  "config": true,
+                  "class": "container",
                   "status": "CURRENT"
                 }
               ],
-              "name": "autoconf",
-              "description": "Parameters to control the autoconfiguration of IPv6\naddresses, as described in RFC 4862.",
+              "name": "ipv6",
+              "description": "Parameters for the IPv6 address family.",
               "config": true,
               "class": "container",
               "status": "CURRENT"
             }
           ],
-          "name": "ipv6",
-          "description": "Parameters for the IPv6 address family.",
+          "name": "/if:interfaces/if:interface/",
+          "description": "IP parameters on interfaces.\n\nIf an interface is not capable of running IP, the server\nmust not allow the client to configure these parameters.",
           "config": true,
-          "class": "container",
+          "class": "augmentation",
           "status": "CURRENT"
-        }
-      ],
-      "name": "/if:interfaces/if:interface/",
-      "description": "IP parameters on interfaces.\n\nIf an interface is not capable of running IP, the server\nmust not allow the client to configure these parameters.",
-      "config": true,
-      "class": "augmentation",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/if:interfaces-state/if:interface/",
-      "children": [
+        },
         {
-          "path": "/if:interfaces-state/if:interface/ip:ipv4/",
-          "type_info": {},
+          "path": "/if:interfaces-state/if:interface/",
           "children": [
             {
-              "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:forwarding/",
-              "type_info": {
-                "description": "",
-                "type": "boolean"
-              },
-              "children": [],
-              "name": "forwarding",
-              "description": "Indicates whether IPv4 packet forwarding is enabled or\ndisabled on this interface.",
-              "config": false,
-              "class": "leaf",
-              "status": "DEPRECATED"
-            },
-            {
-              "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:mtu/",
-              "type_info": {
-                "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.",
-                "type": "ip:mtu"
-              },
-              "children": [],
-              "name": "mtu",
-              "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.",
-              "config": false,
-              "class": "leaf",
-              "status": "DEPRECATED"
-            },
-            {
-              "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/",
+              "path": "/if:interfaces-state/if:interface/ip:ipv4/",
               "type_info": {},
               "children": [
                 {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:ip/",
+                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:forwarding/",
                   "type_info": {
-                    "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv4-address-no-zone"
+                    "description": "",
+                    "type": "boolean"
                   },
                   "children": [],
-                  "name": "ip",
-                  "description": "The IPv4 address on the interface.",
+                  "name": "forwarding",
+                  "description": "Indicates whether IPv4 packet forwarding is enabled or\ndisabled on this interface.",
                   "config": false,
                   "class": "leaf",
                   "status": "DEPRECATED"
                 },
                 {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/",
+                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:mtu/",
+                  "type_info": {
+                    "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.",
+                    "type": "ip:mtu"
+                  },
+                  "children": [],
+                  "name": "mtu",
+                  "description": "The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "DEPRECATED"
+                },
+                {
+                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/",
                   "type_info": {},
                   "children": [
                     {
-                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/ip:prefix-length/",
-                        "type_info": {
-                          "description": "",
-                          "type": "ip:uint8"
-                        },
-                        "children": [],
-                        "name": "prefix-length",
-                        "description": "The length of the subnet prefix.",
-                        "config": false,
-                        "class": "leaf",
-                        "status": "DEPRECATED"
-                      }],
-                      "name": "prefix-length",
-                      "description": "",
+                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv4-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv4 address on the interface.",
                       "config": false,
-                      "class": "case",
-                      "status": "CURRENT"
+                      "class": "leaf",
+                      "status": "DEPRECATED"
                     },
                     {
-                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/",
+                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/",
                       "type_info": {},
-                      "children": [{
-                        "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/ip:netmask/",
-                        "type_info": {
-                          "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
-                          "type": "yang:dotted-quad"
+                      "children": [
+                        {
+                          "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:prefix-length/ip:prefix-length/",
+                            "type_info": {
+                              "description": "",
+                              "type": "ip:uint8"
+                            },
+                            "children": [],
+                            "name": "prefix-length",
+                            "description": "The length of the subnet prefix.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "DEPRECATED"
+                          }],
+                          "name": "prefix-length",
+                          "description": "",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
                         },
-                        "children": [],
-                        "name": "netmask",
-                        "description": "The subnet specified as a netmask.",
-                        "config": false,
-                        "class": "leaf",
-                        "status": "DEPRECATED"
-                      }],
-                      "name": "netmask",
-                      "description": "",
+                        {
+                          "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:subnet/ip:netmask/ip:netmask/",
+                            "type_info": {
+                              "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
+                              "type": "yang:dotted-quad"
+                            },
+                            "children": [],
+                            "name": "netmask",
+                            "description": "The subnet specified as a netmask.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "DEPRECATED"
+                          }],
+                          "name": "netmask",
+                          "description": "",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "subnet",
+                      "description": "The subnet can be specified as a prefix length or,\nif the server supports non-contiguous netmasks, as\na netmask.",
                       "config": false,
-                      "class": "case",
-                      "status": "CURRENT"
+                      "class": "choice",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of an address.",
+                        "type": "ip:ip-address-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this address.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
                     }
                   ],
-                  "name": "subnet",
-                  "description": "The subnet can be specified as a prefix length or,\nif the server supports non-contiguous netmasks, as\na netmask.",
+                  "name": "address",
+                  "description": "The list of IPv4 addresses on the interface.",
                   "config": false,
-                  "class": "choice",
+                  "class": "list",
                   "status": "DEPRECATED"
                 },
                 {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:address/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of an address.",
-                    "type": "ip:ip-address-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this address.",
+                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv4-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv4 address of the neighbor node.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/ip:link-layer-address/",
+                      "type_info": {
+                        "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
+                        "type": "yang:phys-address"
+                      },
+                      "children": [],
+                      "name": "link-layer-address",
+                      "description": "The link-layer address of the neighbor node.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of a neighbor entry.",
+                        "type": "ip:neighbor-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this neighbor entry.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    }
+                  ],
+                  "name": "neighbor",
+                  "description": "A list of mappings from IPv4 addresses to\nlink-layer addresses.\n\nThis list represents the ARP Cache.",
                   "config": false,
-                  "class": "leaf",
+                  "class": "list",
                   "status": "DEPRECATED"
                 }
               ],
-              "name": "address",
-              "description": "The list of IPv4 addresses on the interface.",
+              "name": "ipv4",
+              "description": "Interface-specific parameters for the IPv4 address family.",
               "config": false,
-              "class": "list",
+              "class": "container",
               "status": "DEPRECATED"
             },
             {
-              "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/",
+              "path": "/if:interfaces-state/if:interface/ip:ipv6/",
               "type_info": {},
               "children": [
                 {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/ip:ip/",
+                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:forwarding/",
                   "type_info": {
-                    "description": "An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv4-address-no-zone"
+                    "default": "false",
+                    "description": "Indicates whether IPv6 packet forwarding is enabled or\ndisabled on this interface.",
+                    "type": "ip:forwarding"
                   },
                   "children": [],
-                  "name": "ip",
-                  "description": "The IPv4 address of the neighbor node.",
+                  "name": "forwarding",
+                  "description": "Indicates whether IPv6 packet forwarding is enabled or\ndisabled on this interface.",
                   "config": false,
                   "class": "leaf",
                   "status": "DEPRECATED"
                 },
                 {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/ip:link-layer-address/",
+                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:mtu/",
                   "type_info": {
-                    "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
-                    "type": "yang:phys-address"
+                    "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.",
+                    "type": "ip:mtu"
                   },
                   "children": [],
-                  "name": "link-layer-address",
-                  "description": "The link-layer address of the neighbor node.",
+                  "name": "mtu",
+                  "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.",
                   "config": false,
                   "class": "leaf",
                   "status": "DEPRECATED"
                 },
                 {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv4/ip:neighbor/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of a neighbor entry.",
-                    "type": "ip:neighbor-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this neighbor entry.",
+                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv6-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv6 address on the interface.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:prefix-length/",
+                      "type_info": {
+                        "description": "",
+                        "type": "ip:uint8"
+                      },
+                      "children": [],
+                      "name": "prefix-length",
+                      "description": "The length of the subnet prefix.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of an address.",
+                        "type": "ip:ip-address-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this address.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:status/",
+                      "type_info": {
+                        "description": "",
+                        "type": "ip:enumeration"
+                      },
+                      "children": [],
+                      "name": "status",
+                      "description": "The status of an address.  Most of the states correspond\nto states from the IPv6 Stateless Address\nAutoconfiguration protocol.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    }
+                  ],
+                  "name": "address",
+                  "description": "The list of IPv6 addresses on the interface.",
                   "config": false,
-                  "class": "leaf",
+                  "class": "list",
+                  "status": "DEPRECATED"
+                },
+                {
+                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:ip/",
+                      "type_info": {
+                        "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
+                        "type": "inet:ipv6-address-no-zone"
+                      },
+                      "children": [],
+                      "name": "ip",
+                      "description": "The IPv6 address of the neighbor node.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:link-layer-address/",
+                      "type_info": {
+                        "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
+                        "type": "yang:phys-address"
+                      },
+                      "children": [],
+                      "name": "link-layer-address",
+                      "description": "The link-layer address of the neighbor node.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:origin/",
+                      "type_info": {
+                        "description": "The origin of a neighbor entry.",
+                        "type": "ip:neighbor-origin"
+                      },
+                      "children": [],
+                      "name": "origin",
+                      "description": "The origin of this neighbor entry.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:is-router/",
+                      "type_info": {
+                        "description": "",
+                        "type": "empty"
+                      },
+                      "children": [],
+                      "name": "is-router",
+                      "description": "Indicates that the neighbor node acts as a router.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    },
+                    {
+                      "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:state/",
+                      "type_info": {
+                        "description": "",
+                        "type": "ip:enumeration"
+                      },
+                      "children": [],
+                      "name": "state",
+                      "description": "The Neighbor Unreachability Detection state of this\nentry.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "DEPRECATED"
+                    }
+                  ],
+                  "name": "neighbor",
+                  "description": "A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nThis list represents the Neighbor Cache.",
+                  "config": false,
+                  "class": "list",
                   "status": "DEPRECATED"
                 }
               ],
-              "name": "neighbor",
-              "description": "A list of mappings from IPv4 addresses to\nlink-layer addresses.\n\nThis list represents the ARP Cache.",
+              "name": "ipv6",
+              "description": "Parameters for the IPv6 address family.",
               "config": false,
-              "class": "list",
+              "class": "container",
               "status": "DEPRECATED"
             }
           ],
-          "name": "ipv4",
-          "description": "Interface-specific parameters for the IPv4 address family.",
+          "name": "/if:interfaces-state/if:interface/",
+          "description": "Data nodes for the operational state of IP on interfaces.",
           "config": false,
-          "class": "container",
-          "status": "DEPRECATED"
-        },
-        {
-          "path": "/if:interfaces-state/if:interface/ip:ipv6/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:forwarding/",
-              "type_info": {
-                "default": "false",
-                "description": "Indicates whether IPv6 packet forwarding is enabled or\ndisabled on this interface.",
-                "type": "ip:forwarding"
-              },
-              "children": [],
-              "name": "forwarding",
-              "description": "Indicates whether IPv6 packet forwarding is enabled or\ndisabled on this interface.",
-              "config": false,
-              "class": "leaf",
-              "status": "DEPRECATED"
-            },
-            {
-              "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:mtu/",
-              "type_info": {
-                "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.",
-                "type": "ip:mtu"
-              },
-              "children": [],
-              "name": "mtu",
-              "description": "The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.",
-              "config": false,
-              "class": "leaf",
-              "status": "DEPRECATED"
-            },
-            {
-              "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:ip/",
-                  "type_info": {
-                    "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv6-address-no-zone"
-                  },
-                  "children": [],
-                  "name": "ip",
-                  "description": "The IPv6 address on the interface.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:prefix-length/",
-                  "type_info": {
-                    "description": "",
-                    "type": "ip:uint8"
-                  },
-                  "children": [],
-                  "name": "prefix-length",
-                  "description": "The length of the subnet prefix.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of an address.",
-                    "type": "ip:ip-address-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this address.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:address/ip:status/",
-                  "type_info": {
-                    "description": "",
-                    "type": "ip:enumeration"
-                  },
-                  "children": [],
-                  "name": "status",
-                  "description": "The status of an address.  Most of the states correspond\nto states from the IPv6 Stateless Address\nAutoconfiguration protocol.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                }
-              ],
-              "name": "address",
-              "description": "The list of IPv6 addresses on the interface.",
-              "config": false,
-              "class": "list",
-              "status": "DEPRECATED"
-            },
-            {
-              "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/",
-              "type_info": {},
-              "children": [
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:ip/",
-                  "type_info": {
-                    "description": "An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.",
-                    "type": "inet:ipv6-address-no-zone"
-                  },
-                  "children": [],
-                  "name": "ip",
-                  "description": "The IPv6 address of the neighbor node.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:link-layer-address/",
-                  "type_info": {
-                    "description": "Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.",
-                    "type": "yang:phys-address"
-                  },
-                  "children": [],
-                  "name": "link-layer-address",
-                  "description": "The link-layer address of the neighbor node.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:origin/",
-                  "type_info": {
-                    "description": "The origin of a neighbor entry.",
-                    "type": "ip:neighbor-origin"
-                  },
-                  "children": [],
-                  "name": "origin",
-                  "description": "The origin of this neighbor entry.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:is-router/",
-                  "type_info": {
-                    "description": "",
-                    "type": "empty"
-                  },
-                  "children": [],
-                  "name": "is-router",
-                  "description": "Indicates that the neighbor node acts as a router.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                },
-                {
-                  "path": "/if:interfaces-state/if:interface/ip:ipv6/ip:neighbor/ip:state/",
-                  "type_info": {
-                    "description": "",
-                    "type": "ip:enumeration"
-                  },
-                  "children": [],
-                  "name": "state",
-                  "description": "The Neighbor Unreachability Detection state of this\nentry.",
-                  "config": false,
-                  "class": "leaf",
-                  "status": "DEPRECATED"
-                }
-              ],
-              "name": "neighbor",
-              "description": "A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nThis list represents the Neighbor Cache.",
-              "config": false,
-              "class": "list",
-              "status": "DEPRECATED"
-            }
-          ],
-          "name": "ipv6",
-          "description": "Parameters for the IPv6 address family.",
-          "config": false,
-          "class": "container",
+          "class": "augmentation",
           "status": "DEPRECATED"
         }
-      ],
-      "name": "/if:interfaces-state/if:interface/",
-      "description": "Data nodes for the operational state of IP on interfaces.",
-      "config": false,
-      "class": "augmentation",
-      "status": "DEPRECATED"
+      ]
     }
   ]
 }

--- a/src/test/resources/out/compare/multipleModules.json
+++ b/src/test/resources/out/compare/multipleModules.json
@@ -1,0 +1,3246 @@
+{"parsed-models": [
+  {
+    "children": [{
+      "path": "/co-oam:domains/",
+      "type_info": {},
+      "children": [{
+        "path": "/co-oam:domains/co-oam:domain/",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/co-oam:domains/co-oam:domain/co-oam:technology/",
+            "type_info": {
+              "description": "",
+              "type": "identityref",
+              "base": ["technology-types"]
+            },
+            "children": [],
+            "name": "technology",
+            "description": "Defines the technology.",
+            "config": true,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:domains/co-oam:domain/co-oam:md-name-string/",
+            "type_info": {
+              "description": "Generic administrative name for Maintenance Domain (MD).",
+              "type": "co-oam:md-name-string"
+            },
+            "children": [],
+            "name": "md-name-string",
+            "description": "Defines the generic administrative Maintenance Domain name.",
+            "config": true,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:domains/co-oam:domain/co-oam:md-name-format/",
+            "type_info": {
+              "description": "",
+              "type": "identityref",
+              "base": ["name-format"]
+            },
+            "children": [],
+            "name": "md-name-format",
+            "description": "Maintenance Domain Name format.",
+            "config": true,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/",
+            "type_info": {},
+            "children": [{
+              "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/co-oam:md-name-null/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:domains/co-oam:domain/co-oam:md-name/co-oam:md-name-null/co-oam:md-name-null/",
+                "type_info": {
+                  "description": "",
+                  "type": "empty"
+                },
+                "children": [],
+                "name": "md-name-null",
+                "description": "MD name null.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              }],
+              "name": "md-name-null",
+              "description": "",
+              "config": true,
+              "class": "case",
+              "status": "CURRENT"
+            }],
+            "name": "md-name",
+            "description": "MD name.",
+            "config": true,
+            "class": "choice",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:domains/co-oam:domain/co-oam:md-level/",
+            "type_info": {
+              "description": "Maintenance Domain Level.  The level may be restricted in\ncertain protocols (e.g., protocol in layer 0 to layer 7).",
+              "type": "co-oam:md-level"
+            },
+            "children": [],
+            "name": "md-level",
+            "description": "Define the MD level.",
+            "config": true,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/",
+            "type_info": {},
+            "children": [{
+              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name-string/",
+                  "type_info": {
+                    "description": "Generic administrative name for a\nMaintenance Association (MA).",
+                    "type": "co-oam:ma-name-string"
+                  },
+                  "children": [],
+                  "name": "ma-name-string",
+                  "description": "MA name string.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name-format/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["name-format"]
+                  },
+                  "children": [],
+                  "name": "ma-name-format",
+                  "description": "MA name format.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/co-oam:ma-name-null/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:ma-name/co-oam:ma-name-null/co-oam:ma-name-null/",
+                      "type_info": {
+                        "description": "",
+                        "type": "empty"
+                      },
+                      "children": [],
+                      "name": "ma-name-null",
+                      "description": "Empty",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }],
+                    "name": "ma-name-null",
+                    "description": "",
+                    "config": true,
+                    "class": "case",
+                    "status": "CURRENT"
+                  }],
+                  "name": "ma-name",
+                  "description": "MA name.",
+                  "config": true,
+                  "class": "choice",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/co-oam:context-null/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:connectivity-context/co-oam:context-null/co-oam:context-null/",
+                      "type_info": {
+                        "description": "",
+                        "type": "empty"
+                      },
+                      "children": [],
+                      "name": "context-null",
+                      "description": "There is no context to be defined.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }],
+                    "name": "context-null",
+                    "description": "This is a placeholder when no context is needed.",
+                    "config": true,
+                    "class": "case",
+                    "status": "CURRENT"
+                  }],
+                  "name": "connectivity-context",
+                  "description": "Connectivity context.",
+                  "config": true,
+                  "class": "choice",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:cos-id/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "cos-id",
+                  "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:cc-enable/",
+                  "type_info": {
+                    "description": "",
+                    "type": "boolean"
+                  },
+                  "children": [],
+                  "name": "cc-enable",
+                  "description": "Indicate whether the CC is enabled.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-name/",
+                      "type_info": {
+                        "description": "Generic administrative name for a MEP.",
+                        "type": "co-oam:mep-name"
+                      },
+                      "children": [],
+                      "name": "mep-name",
+                      "description": "Generic administrative name of the\nMEP.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/co-oam:mep-id-int/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                          "type_info": {
+                            "description": "",
+                            "type": "int32"
+                          },
+                          "children": [],
+                          "name": "mep-id-int",
+                          "description": "MEP ID\nin integer format.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mep-id-int",
+                        "description": "",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id",
+                      "description": "MEP ID.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-id-format/",
+                      "type_info": {
+                        "description": "",
+                        "type": "identityref",
+                        "base": ["identifier-format"]
+                      },
+                      "children": [],
+                      "name": "mep-id-format",
+                      "description": "MEP ID format.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MEP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mep-address",
+                      "description": "MEP Addressing.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:cos-id/",
+                      "type_info": {
+                        "description": "",
+                        "type": "uint8"
+                      },
+                      "children": [],
+                      "name": "cos-id",
+                      "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:cc-enable/",
+                      "type_info": {
+                        "description": "",
+                        "type": "boolean"
+                      },
+                      "children": [],
+                      "name": "cc-enable",
+                      "description": "Indicate whether the CC is enabled.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:session-cookie/",
+                          "type_info": {
+                            "description": "",
+                            "type": "uint32"
+                          },
+                          "children": [],
+                          "name": "session-cookie",
+                          "description": "Cookie to identify different sessions, when there\nare multiple remote MEPs or multiple sessions to\nthe same remote MEP.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/",
+                          "type_info": {},
+                          "children": [
+                            {
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                                "type_info": {},
+                                "children": [{
+                                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                                  "type_info": {
+                                    "description": "",
+                                    "type": "int32"
+                                  },
+                                  "children": [],
+                                  "name": "mep-id-int",
+                                  "description": "MEP ID\nin integer format.",
+                                  "config": true,
+                                  "class": "leaf",
+                                  "status": "CURRENT"
+                                }],
+                                "name": "mep-id-int",
+                                "description": "",
+                                "config": true,
+                                "class": "case",
+                                "status": "CURRENT"
+                              }],
+                              "name": "mep-id",
+                              "description": "MEP ID.",
+                              "config": true,
+                              "class": "choice",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep/co-oam:mep-id-format/",
+                              "type_info": {
+                                "description": "",
+                                "type": "identityref",
+                                "base": ["identifier-format"]
+                              },
+                              "children": [],
+                              "name": "mep-id-format",
+                              "description": "MEP ID format.",
+                              "config": true,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }
+                          ],
+                          "name": "destination-mep",
+                          "description": "Destination MEP.",
+                          "config": true,
+                          "class": "container",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/",
+                            "type_info": {},
+                            "children": [
+                              {
+                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:mac-address/",
+                                "type_info": {},
+                                "children": [{
+                                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                                  "type_info": {
+                                    "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                                    "type": "yang:mac-address"
+                                  },
+                                  "children": [],
+                                  "name": "mac-address",
+                                  "description": "MAC Address.",
+                                  "config": true,
+                                  "class": "leaf",
+                                  "status": "CURRENT"
+                                }],
+                                "name": "mac-address",
+                                "description": "MAC Address based MEP Addressing.",
+                                "config": true,
+                                "class": "case",
+                                "status": "CURRENT"
+                              },
+                              {
+                                "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:ip-address/",
+                                "type_info": {},
+                                "children": [{
+                                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:destination-mep-address/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                                  "type_info": {
+                                    "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                                    "type": "inet:ip-address"
+                                  },
+                                  "children": [],
+                                  "name": "ip-address",
+                                  "description": "IP Address.",
+                                  "config": true,
+                                  "class": "leaf",
+                                  "status": "CURRENT"
+                                }],
+                                "name": "ip-address",
+                                "description": "IP Address based MEP Addressing.",
+                                "config": true,
+                                "class": "case",
+                                "status": "CURRENT"
+                              }
+                            ],
+                            "name": "mep-address",
+                            "description": "MEP Addressing.",
+                            "config": true,
+                            "class": "choice",
+                            "status": "CURRENT"
+                          }],
+                          "name": "destination-mep-address",
+                          "description": "Destination MEP Address.",
+                          "config": true,
+                          "class": "container",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mep/co-oam:session/co-oam:cos-id/",
+                          "type_info": {
+                            "description": "",
+                            "type": "uint8"
+                          },
+                          "children": [],
+                          "name": "cos-id",
+                          "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "session",
+                      "description": "Monitoring session to/from a particular remote MEP.\nDepending on the protocol, this could represent\nCC messages received from a single remote MEP (if the\nprotocol uses multicast CCs) or a target to which\nunicast echo request CCs are sent and from which\nresponses are received (if the protocol uses a\nunicast request/response mechanism).",
+                      "config": true,
+                      "class": "list",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "mep",
+                  "description": "Contain a list of MEPs.",
+                  "config": true,
+                  "class": "list",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:name/",
+                      "type_info": {
+                        "description": "",
+                        "type": "string"
+                      },
+                      "children": [],
+                      "name": "name",
+                      "description": "Identifier of Maintenance Intermediate Point",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:interface/",
+                      "type_info": {
+                        "description": "This type is used by data models that need to reference\ninterfaces.",
+                        "type": "if:interface-ref"
+                      },
+                      "children": [],
+                      "name": "interface",
+                      "description": "Interface.",
+                      "config": true,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address of Maintenance Intermediate Point",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MIP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:domains/co-oam:domain/co-oam:mas/co-oam:ma/co-oam:mip/co-oam:mip-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": true,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MIP Addressing.",
+                          "config": true,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mip-address",
+                      "description": "MIP Addressing.",
+                      "config": true,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "mip",
+                  "description": "List for MIP.",
+                  "config": true,
+                  "class": "list",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "ma",
+              "description": "Maintenance Association list.",
+              "config": true,
+              "class": "list",
+              "status": "CURRENT"
+            }],
+            "name": "mas",
+            "description": "Contains configuration-related data.  Within the\ncontainer, there is a list of MAs.  Each MA has a\nlist of MEPs.",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "domain",
+        "description": "Define a list of Domains within the\nietf-connection-oriented-oam module.",
+        "config": true,
+        "class": "list",
+        "status": "CURRENT"
+      }],
+      "name": "domains",
+      "description": "Contains configuration related data.  Within the\ncontainer, there is a list of fault domains.  Each\ndomain has a list of MAs.",
+      "config": true,
+      "class": "container",
+      "status": "CURRENT"
+    }],
+    "module": {
+      "prefix": "co-oam",
+      "contact": "WG Web:    http://datatracker.ietf.org/wg/lime\nWG List:   <mailto:lime@ietf.org>\nEditor:    Deepak Kumar <dekumar@cisco.com>\nEditor:    Qin Wu <bill.wu@huawei.com>\nEditor:    Michael Wang <wangzitao@huawei.com>",
+      "name": "ietf-connection-oriented-oam",
+      "namespace": "urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam",
+      "description": "This YANG module defines the generic configuration,\nstatistics and RPC for connection-oriented OAM\nto be used within IETF in a protocol-independent manner.\nFunctional-level abstraction is independent\nwith YANG modeling. It is assumed that each protocol\nmaps corresponding abstracts to its native format.\nEach protocol may extend the YANG data model defined\nhere to include protocol-specific extensions\n\nCopyright (c) 2019 IETF Trust and the persons identified as\nauthors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(http://trustee.ietf.org/license-info).\n\nThis version of this YANG module is part of RFC 8531; see\nthe RFC itself for full legal notices.",
+      "revision": "2019-04-16"
+    },
+    "rpcs": [
+      {
+        "path": "/co-oam:continuity-check/",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/co-oam:continuity-check/co-oam:input/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:technology/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["technology-types"]
+                },
+                "children": [],
+                "name": "technology",
+                "description": "The technology.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:md-name-string/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "md-name-string",
+                "description": "Indicate which MD the defect belongs to.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:md-level/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "md-level",
+                "description": "The Maintenance Domain Level.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:ma-name-string/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "ma-name-string",
+                "description": "Indicate which MA the defect is associated with.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:cos-id/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "cos-id",
+                "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:ttl/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "ttl",
+                "description": "Time to Live.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:sub-type/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["command-sub-type"]
+                },
+                "children": [],
+                "name": "sub-type",
+                "description": "Defines different command types.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:source-mep/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "source-mep",
+                "description": "Source MEP.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                          "type_info": {
+                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                            "type": "yang:mac-address"
+                          },
+                          "children": [],
+                          "name": "mac-address",
+                          "description": "MAC Address.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mac-address",
+                        "description": "MAC Address based MEP Addressing.",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                          "type_info": {
+                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                            "type": "inet:ip-address"
+                          },
+                          "children": [],
+                          "name": "ip-address",
+                          "description": "IP Address.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "ip-address",
+                        "description": "IP Address based MEP Addressing.",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "mep-address",
+                    "description": "MEP Addressing.",
+                    "config": true,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                        "type_info": {
+                          "description": "",
+                          "type": "int32"
+                        },
+                        "children": [],
+                        "name": "mep-id-int",
+                        "description": "MEP ID\nin integer format.",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id-int",
+                      "description": "",
+                      "config": true,
+                      "class": "case",
+                      "status": "CURRENT"
+                    }],
+                    "name": "mep-id",
+                    "description": "MEP ID.",
+                    "config": true,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:continuity-check/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["identifier-format"]
+                    },
+                    "children": [],
+                    "name": "mep-id-format",
+                    "description": "MEP ID format.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "destination-mep",
+                "description": "Destination MEP.",
+                "config": true,
+                "class": "container",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:count/",
+                "type_info": {
+                  "default": "3",
+                  "description": "Number of continuity-check messages to be sent.",
+                  "type": "co-oam:count"
+                },
+                "children": [],
+                "name": "count",
+                "description": "Number of continuity-check messages to be sent.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:cc-transmit-interval/",
+                "type_info": {
+                  "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
+                  "type": "co-oam:time-interval"
+                },
+                "children": [],
+                "name": "cc-transmit-interval",
+                "description": "Time interval between echo requests.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-check/co-oam:input/co-oam:packet-size/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:uint32"
+                },
+                "children": [],
+                "name": "packet-size",
+                "description": "Size of continuity-check packets, in octets.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "input",
+            "description": "",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:continuity-check/co-oam:output/",
+            "type_info": {},
+            "children": [{
+              "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:continuity-check/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
+                  "type_info": {
+                    "description": "",
+                    "type": "empty"
+                  },
+                  "children": [],
+                  "name": "monitor-null",
+                  "description": "There are no monitoring statistics to be defined.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }],
+                "name": "monitor-null",
+                "description": "This is a placeholder when\nno monitoring statistics are needed.",
+                "config": false,
+                "class": "case",
+                "status": "CURRENT"
+              }],
+              "name": "monitor-stats",
+              "description": "Define the monitor stats.",
+              "config": false,
+              "class": "choice",
+              "status": "CURRENT"
+            }],
+            "name": "output",
+            "description": "",
+            "config": false,
+            "class": "container",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "continuity-check",
+        "description": "Generates Continuity Check as per Table 4 of RFC 7276.",
+        "class": "rpc",
+        "status": "CURRENT"
+      },
+      {
+        "path": "/co-oam:continuity-verification/",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/co-oam:continuity-verification/co-oam:input/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:md-name-string/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "md-name-string",
+                "description": "Indicate which MD the defect belongs to.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:md-level/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "md-level",
+                "description": "The Maintenance Domain Level.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:ma-name-string/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "ma-name-string",
+                "description": "Indicate which MA the defect is associated with.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:cos-id/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "cos-id",
+                "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:ttl/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "ttl",
+                "description": "Time to Live.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:sub-type/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["command-sub-type"]
+                },
+                "children": [],
+                "name": "sub-type",
+                "description": "Defines different command types.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:source-mep/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "source-mep",
+                "description": "Source MEP.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                          "type_info": {
+                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                            "type": "yang:mac-address"
+                          },
+                          "children": [],
+                          "name": "mac-address",
+                          "description": "MAC Address.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mac-address",
+                        "description": "MAC Address based MEP Addressing.",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                          "type_info": {
+                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                            "type": "inet:ip-address"
+                          },
+                          "children": [],
+                          "name": "ip-address",
+                          "description": "IP Address.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "ip-address",
+                        "description": "IP Address based MEP Addressing.",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "mep-address",
+                    "description": "MEP Addressing.",
+                    "config": true,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                        "type_info": {
+                          "description": "",
+                          "type": "int32"
+                        },
+                        "children": [],
+                        "name": "mep-id-int",
+                        "description": "MEP ID\nin integer format.",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id-int",
+                      "description": "",
+                      "config": true,
+                      "class": "case",
+                      "status": "CURRENT"
+                    }],
+                    "name": "mep-id",
+                    "description": "MEP ID.",
+                    "config": true,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:continuity-verification/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["identifier-format"]
+                    },
+                    "children": [],
+                    "name": "mep-id-format",
+                    "description": "MEP ID format.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "destination-mep",
+                "description": "Destination MEP.",
+                "config": true,
+                "class": "container",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:count/",
+                "type_info": {
+                  "default": "3",
+                  "description": "Number of continuity-verification messages to be sent.",
+                  "type": "co-oam:count"
+                },
+                "children": [],
+                "name": "count",
+                "description": "Number of continuity-verification messages to be sent.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:interval/",
+                "type_info": {
+                  "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
+                  "type": "co-oam:time-interval"
+                },
+                "children": [],
+                "name": "interval",
+                "description": "Time interval between echo requests.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:continuity-verification/co-oam:input/co-oam:packet-size/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:uint32"
+                },
+                "children": [],
+                "name": "packet-size",
+                "description": "Size of continuity-verification packets, in octets.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "input",
+            "description": "",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:continuity-verification/co-oam:output/",
+            "type_info": {},
+            "children": [{
+              "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/",
+              "type_info": {},
+              "children": [{
+                "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:continuity-verification/co-oam:output/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
+                  "type_info": {
+                    "description": "",
+                    "type": "empty"
+                  },
+                  "children": [],
+                  "name": "monitor-null",
+                  "description": "There are no monitoring statistics to be defined.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }],
+                "name": "monitor-null",
+                "description": "This is a placeholder when\nno monitoring statistics are needed.",
+                "config": false,
+                "class": "case",
+                "status": "CURRENT"
+              }],
+              "name": "monitor-stats",
+              "description": "Define the monitor stats.",
+              "config": false,
+              "class": "choice",
+              "status": "CURRENT"
+            }],
+            "name": "output",
+            "description": "",
+            "config": false,
+            "class": "container",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "continuity-verification",
+        "description": "Generates Connectivity Verification as per Table 4 in RFC 7276.",
+        "class": "rpc",
+        "status": "CURRENT"
+      },
+      {
+        "path": "/co-oam:traceroute/",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/co-oam:traceroute/co-oam:input/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:md-name-string/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "md-name-string",
+                "description": "Indicate which MD the defect belongs to.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:md-level/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "md-level",
+                "description": "The Maintenance Domain Level.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:ma-name-string/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "ma-name-string",
+                "description": "Indicate which MA the defect is associated with.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:cos-id/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "cos-id",
+                "description": "Class of Service (CoS) ID; this value is used to indicate\nClass of Service information .",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:ttl/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint8"
+                },
+                "children": [],
+                "name": "ttl",
+                "description": "Time to Live.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:command-sub-type/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["command-sub-type"]
+                },
+                "children": [],
+                "name": "command-sub-type",
+                "description": "Defines different command types.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:source-mep/",
+                "type_info": {
+                  "description": "",
+                  "type": "co-oam:leafref"
+                },
+                "children": [],
+                "name": "source-mep",
+                "description": "Source MEP.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                          "type_info": {
+                            "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                            "type": "yang:mac-address"
+                          },
+                          "children": [],
+                          "name": "mac-address",
+                          "description": "MAC Address.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mac-address",
+                        "description": "MAC Address based MEP Addressing.",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                          "type_info": {
+                            "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                            "type": "inet:ip-address"
+                          },
+                          "children": [],
+                          "name": "ip-address",
+                          "description": "IP Address.",
+                          "config": true,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "ip-address",
+                        "description": "IP Address based MEP Addressing.",
+                        "config": true,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "mep-address",
+                    "description": "MEP Addressing.",
+                    "config": true,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                        "type_info": {
+                          "description": "",
+                          "type": "int32"
+                        },
+                        "children": [],
+                        "name": "mep-id-int",
+                        "description": "MEP ID\nin integer format.",
+                        "config": true,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id-int",
+                      "description": "",
+                      "config": true,
+                      "class": "case",
+                      "status": "CURRENT"
+                    }],
+                    "name": "mep-id",
+                    "description": "MEP ID.",
+                    "config": true,
+                    "class": "choice",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/co-oam:traceroute/co-oam:input/co-oam:destination-mep/co-oam:mep-id-format/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["identifier-format"]
+                    },
+                    "children": [],
+                    "name": "mep-id-format",
+                    "description": "MEP ID format.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "destination-mep",
+                "description": "Destination MEP.",
+                "config": true,
+                "class": "container",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:count/",
+                "type_info": {
+                  "default": "1",
+                  "description": "Number of traceroute probes to send.  In protocols where a\nseparate message is sent at each TTL, this is the number\nof packets to be sent at each TTL.",
+                  "type": "co-oam:count"
+                },
+                "children": [],
+                "name": "count",
+                "description": "Number of traceroute probes to send.  In protocols where a\nseparate message is sent at each TTL, this is the number\nof packets to be sent at each TTL.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:traceroute/co-oam:input/co-oam:interval/",
+                "type_info": {
+                  "description": "Time interval between packets in milliseconds.\nTime interval should not be less than 0.\n0 means no packets are sent.",
+                  "type": "co-oam:time-interval"
+                },
+                "children": [],
+                "name": "interval",
+                "description": "Time interval between echo requests.",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "input",
+            "description": "",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:traceroute/co-oam:output/",
+            "type_info": {},
+            "children": [{
+              "path": "/co-oam:traceroute/co-oam:output/co-oam:response/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:response-index/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "response-index",
+                  "description": "Arbitrary index for the response.  In protocols that\nguarantee there is only a single response at each TTL,\nthe TTL can be used as the response index.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:ttl/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint8"
+                  },
+                  "children": [],
+                  "name": "ttl",
+                  "description": "Time to Live.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MEP Addressing.",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MEP Addressing.",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mep-address",
+                      "description": "MEP Addressing.",
+                      "config": false,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                          "type_info": {
+                            "description": "",
+                            "type": "int32"
+                          },
+                          "children": [],
+                          "name": "mep-id-int",
+                          "description": "MEP ID\nin integer format.",
+                          "config": false,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        }],
+                        "name": "mep-id-int",
+                        "description": "",
+                        "config": false,
+                        "class": "case",
+                        "status": "CURRENT"
+                      }],
+                      "name": "mep-id",
+                      "description": "MEP ID.",
+                      "config": false,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:destination-mep/co-oam:mep-id-format/",
+                      "type_info": {
+                        "description": "",
+                        "type": "identityref",
+                        "base": ["identifier-format"]
+                      },
+                      "children": [],
+                      "name": "mep-id-format",
+                      "description": "MEP ID format.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "destination-mep",
+                  "description": "MEP from which the response has been received",
+                  "config": false,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:interface/",
+                      "type_info": {
+                        "description": "This type is used by data models that need to reference\ninterfaces.",
+                        "type": "if:interface-ref"
+                      },
+                      "children": [],
+                      "name": "interface",
+                      "description": "MIP interface.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/",
+                      "type_info": {},
+                      "children": [
+                        {
+                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:mac-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:mac-address/co-oam:mac-address/",
+                            "type_info": {
+                              "description": "The mac-address type represents an IEEE 802 MAC address.\nThe canonical representation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the MacAddress textual convention of the SMIv2.",
+                              "type": "yang:mac-address"
+                            },
+                            "children": [],
+                            "name": "mac-address",
+                            "description": "MAC Address of Maintenance Intermediate Point",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "mac-address",
+                          "description": "MAC Address based MIP Addressing.",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:ip-address/",
+                          "type_info": {},
+                          "children": [{
+                            "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:mip/co-oam:mip-address/co-oam:ip-address/co-oam:ip-address/",
+                            "type_info": {
+                              "description": "The ip-address type represents an IP address and is IP\nversion neutral.  The format of the textual representation\nimplies the IP version.  This type supports scoped addresses\nby allowing zone identifiers in the address format.",
+                              "type": "inet:ip-address"
+                            },
+                            "children": [],
+                            "name": "ip-address",
+                            "description": "IP Address.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }],
+                          "name": "ip-address",
+                          "description": "IP Address based MIP Addressing.",
+                          "config": false,
+                          "class": "case",
+                          "status": "CURRENT"
+                        }
+                      ],
+                      "name": "mip-address",
+                      "description": "MIP Addressing.",
+                      "config": false,
+                      "class": "choice",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "mip",
+                  "description": "MIP responding with traceroute",
+                  "config": false,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/co-oam:monitor-null/",
+                    "type_info": {},
+                    "children": [{
+                      "path": "/co-oam:traceroute/co-oam:output/co-oam:response/co-oam:monitor-stats/co-oam:monitor-null/co-oam:monitor-null/",
+                      "type_info": {
+                        "description": "",
+                        "type": "empty"
+                      },
+                      "children": [],
+                      "name": "monitor-null",
+                      "description": "There are no monitoring statistics to be defined.",
+                      "config": false,
+                      "class": "leaf",
+                      "status": "CURRENT"
+                    }],
+                    "name": "monitor-null",
+                    "description": "This is a placeholder when\nno monitoring statistics are needed.",
+                    "config": false,
+                    "class": "case",
+                    "status": "CURRENT"
+                  }],
+                  "name": "monitor-stats",
+                  "description": "Define the monitor stats.",
+                  "config": false,
+                  "class": "choice",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "response",
+              "description": "List of responses.",
+              "config": false,
+              "class": "list",
+              "status": "CURRENT"
+            }],
+            "name": "output",
+            "description": "",
+            "config": false,
+            "class": "container",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "traceroute",
+        "description": "Generates Traceroute or Path Trace and returns response.\nReferences RFC 7276 for common Toolset name -- for\nMPLS-TP OAM, it's Route Tracing, and for TRILL OAM, it's\nPath Tracing tool.  Starts with TTL of one and increments\nby one at each hop until the destination is reached or TTL\nreaches max value.",
+        "class": "rpc",
+        "status": "CURRENT"
+      }
+    ],
+    "notifications": [
+      {
+        "path": "Absolute{qnames=[(urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam?revision=2019-04-16)defect-condition-notification]}",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:technology/",
+            "type_info": {
+              "description": "",
+              "type": "identityref",
+              "base": ["technology-types"]
+            },
+            "children": [],
+            "name": "technology",
+            "description": "The technology.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:md-name-string/",
+            "type_info": {
+              "description": "",
+              "type": "co-oam:leafref"
+            },
+            "children": [],
+            "name": "md-name-string",
+            "description": "Indicate which MD the defect belongs to.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:ma-name-string/",
+            "type_info": {
+              "description": "",
+              "type": "co-oam:leafref"
+            },
+            "children": [],
+            "name": "ma-name-string",
+            "description": "Indicate which MA the defect is associated with.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:mep-name/",
+            "type_info": {
+              "description": "",
+              "type": "co-oam:leafref"
+            },
+            "children": [],
+            "name": "mep-name",
+            "description": "Indicate which MEP is seeing the defect.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:defect-type/",
+            "type_info": {
+              "description": "",
+              "type": "identityref",
+              "base": ["defect-types"]
+            },
+            "children": [],
+            "name": "defect-type",
+            "description": "The currently active defects on the specific MEP.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                    "type_info": {
+                      "description": "",
+                      "type": "int32"
+                    },
+                    "children": [],
+                    "name": "mep-id-int",
+                    "description": "MEP ID\nin integer format.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "mep-id-int",
+                  "description": "",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
+                }],
+                "name": "mep-id",
+                "description": "MEP ID.",
+                "config": false,
+                "class": "choice",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:defect-condition-notification/co-oam:generating-mepid/co-oam:mep-id-format/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["identifier-format"]
+                },
+                "children": [],
+                "name": "mep-id-format",
+                "description": "MEP ID format.",
+                "config": false,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "generating-mepid",
+            "description": "Indicate who is generating the defect (if known). If\nunknown, set it to 0.",
+            "config": false,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-condition-notification/co-oam:defect/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-null/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-null/co-oam:defect-null/",
+                  "type_info": {
+                    "description": "",
+                    "type": "empty"
+                  },
+                  "children": [],
+                  "name": "defect-null",
+                  "description": "There is no defect to be defined; it will be defined in\na technology-specific model.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }],
+                "name": "defect-null",
+                "description": "This is a placeholder when no defect status is needed.",
+                "config": false,
+                "class": "case",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-code/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:defect-condition-notification/co-oam:defect/co-oam:defect-code/co-oam:defect-code/",
+                  "type_info": {
+                    "description": "",
+                    "type": "int32"
+                  },
+                  "children": [],
+                  "name": "defect-code",
+                  "description": "Defect code is integer value specific to a technology.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }],
+                "name": "defect-code",
+                "description": "This is a placeholder to display defect code.",
+                "config": false,
+                "class": "case",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "defect",
+            "description": "Defect Message choices.",
+            "config": false,
+            "class": "choice",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "defect-condition-notification",
+        "description": "When the defect condition is met, this notification is sent.",
+        "class": "notification",
+        "status": "CURRENT"
+      },
+      {
+        "path": "Absolute{qnames=[(urn:ietf:params:xml:ns:yang:ietf-connection-oriented-oam?revision=2019-04-16)defect-cleared-notification]}",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:technology/",
+            "type_info": {
+              "description": "",
+              "type": "identityref",
+              "base": ["technology-types"]
+            },
+            "children": [],
+            "name": "technology",
+            "description": "The technology.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:md-name-string/",
+            "type_info": {
+              "description": "",
+              "type": "co-oam:leafref"
+            },
+            "children": [],
+            "name": "md-name-string",
+            "description": "Indicate which MD the defect belongs to",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:ma-name-string/",
+            "type_info": {
+              "description": "",
+              "type": "co-oam:leafref"
+            },
+            "children": [],
+            "name": "ma-name-string",
+            "description": "Indicate which MA the defect is associated with.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:mep-name/",
+            "type_info": {
+              "description": "",
+              "type": "co-oam:leafref"
+            },
+            "children": [],
+            "name": "mep-name",
+            "description": "Indicate which MEP is seeing the defect.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:defect-type/",
+            "type_info": {
+              "description": "",
+              "type": "identityref",
+              "base": ["defect-types"]
+            },
+            "children": [],
+            "name": "defect-type",
+            "description": "The currently active defects on the specific MEP.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id/co-oam:mep-id-int/co-oam:mep-id-int/",
+                    "type_info": {
+                      "description": "",
+                      "type": "int32"
+                    },
+                    "children": [],
+                    "name": "mep-id-int",
+                    "description": "MEP ID\nin integer format.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "mep-id-int",
+                  "description": "",
+                  "config": false,
+                  "class": "case",
+                  "status": "CURRENT"
+                }],
+                "name": "mep-id",
+                "description": "MEP ID.",
+                "config": false,
+                "class": "choice",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:defect-cleared-notification/co-oam:generating-mepid/co-oam:mep-id-format/",
+                "type_info": {
+                  "description": "",
+                  "type": "identityref",
+                  "base": ["identifier-format"]
+                },
+                "children": [],
+                "name": "mep-id-format",
+                "description": "MEP ID format.",
+                "config": false,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "generating-mepid",
+            "description": "Indicate who is generating the defect (if known). If\nunknown, set it to 0.",
+            "config": false,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/co-oam:defect-cleared-notification/co-oam:defect/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-null/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-null/co-oam:defect-null/",
+                  "type_info": {
+                    "description": "",
+                    "type": "empty"
+                  },
+                  "children": [],
+                  "name": "defect-null",
+                  "description": "There is no defect to be defined; it will be defined in\na technology-specific model.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }],
+                "name": "defect-null",
+                "description": "This is a placeholder when no defect status is needed.",
+                "config": false,
+                "class": "case",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-code/",
+                "type_info": {},
+                "children": [{
+                  "path": "/co-oam:defect-cleared-notification/co-oam:defect/co-oam:defect-code/co-oam:defect-code/",
+                  "type_info": {
+                    "description": "",
+                    "type": "int32"
+                  },
+                  "children": [],
+                  "name": "defect-code",
+                  "description": "Defect code is integer value specific to a technology.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }],
+                "name": "defect-code",
+                "description": "This is a placeholder to display defect code.",
+                "config": false,
+                "class": "case",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "defect",
+            "description": "Defect Message choices.",
+            "config": false,
+            "class": "choice",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "defect-cleared-notification",
+        "description": "When the defect is cleared, this notification is sent.",
+        "class": "notification",
+        "status": "CURRENT"
+      }
+    ]
+  },
+  {
+    "children": [
+      {
+        "path": "/rt:routing/",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/rt:routing/rt:router-id/",
+            "type_info": {
+              "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
+              "type": "yang:dotted-quad"
+            },
+            "children": [],
+            "name": "router-id",
+            "description": "A 32-bit number in the form of a dotted quad that is used by\nsome routing protocols identifying a router.",
+            "config": true,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/rt:routing/rt:interfaces/",
+            "type_info": {},
+            "children": [{
+              "path": "/rt:routing/rt:interfaces/rt:interface/",
+              "type_info": {
+                "description": "This type is used by data models that need to reference\ninterfaces.",
+                "type": "if:interface-ref"
+              },
+              "children": [],
+              "name": "interface",
+              "description": "Each entry is a reference to the name of a configured\nnetwork-layer interface.",
+              "config": false,
+              "class": "leaf-list",
+              "status": "CURRENT"
+            }],
+            "name": "interfaces",
+            "description": "Network-layer interfaces used for routing.",
+            "config": false,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/rt:routing/rt:control-plane-protocols/",
+            "type_info": {},
+            "children": [{
+              "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:type/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["control-plane-protocol"]
+                  },
+                  "children": [],
+                  "name": "type",
+                  "description": "Type of the control-plane protocol -- an identity\nderived from the 'control-plane-protocol'\nbase identity.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:name/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "name",
+                  "description": "An arbitrary name of the control-plane protocol\ninstance.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:description/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "description",
+                  "description": "Textual description of the control-plane protocol\ninstance.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:static-routes/",
+                  "type_info": {},
+                  "name": "static-routes",
+                  "description": "Support for the 'static' pseudo-protocol.\n\nAddress-family-specific modules augment this node with\ntheir lists of routes.",
+                  "config": true,
+                  "class": "container",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "control-plane-protocol",
+              "description": "Each entry contains a control-plane protocol instance.",
+              "config": true,
+              "class": "list",
+              "status": "CURRENT"
+            }],
+            "name": "control-plane-protocols",
+            "description": "Support for control-plane protocol instances.",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/rt:routing/rt:ribs/",
+            "type_info": {},
+            "children": [{
+              "path": "/rt:routing/rt:ribs/rt:rib/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:input/",
+                      "type_info": {},
+                      "name": "input",
+                      "description": "",
+                      "config": true,
+                      "class": "container",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/",
+                              "type_info": {},
+                              "children": [
+                                {
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                    "type_info": {
+                                      "description": "This type is used by data models that need to reference\ninterfaces.",
+                                      "type": "if:interface-ref"
+                                    },
+                                    "children": [],
+                                    "name": "outgoing-interface",
+                                    "description": "Name of the outgoing interface.",
+                                    "config": false,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "simple-next-hop",
+                                  "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
+                                  "config": false,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                },
+                                {
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                    "type_info": {
+                                      "description": "",
+                                      "type": "rt:enumeration"
+                                    },
+                                    "children": [],
+                                    "name": "special-next-hop",
+                                    "description": "Options for special next hops.",
+                                    "config": false,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "special-next-hop",
+                                  "description": "",
+                                  "config": false,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                },
+                                {
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                      "type_info": {},
+                                      "children": [{
+                                        "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                        "type_info": {
+                                          "description": "This type is used by data models that need to reference\ninterfaces.",
+                                          "type": "if:interface-ref"
+                                        },
+                                        "children": [],
+                                        "name": "outgoing-interface",
+                                        "description": "Name of the outgoing interface.",
+                                        "config": false,
+                                        "class": "leaf",
+                                        "status": "CURRENT"
+                                      }],
+                                      "name": "next-hop",
+                                      "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
+                                      "config": false,
+                                      "class": "list",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "next-hop-list",
+                                    "description": "Container for multiple next hops.",
+                                    "config": false,
+                                    "class": "container",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "next-hop-list",
+                                  "description": "",
+                                  "config": false,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                }
+                              ],
+                              "name": "next-hop-options",
+                              "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
+                              "config": false,
+                              "class": "choice",
+                              "status": "CURRENT"
+                            }],
+                            "name": "next-hop",
+                            "description": "Route's next-hop attribute.",
+                            "config": false,
+                            "class": "container",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:source-protocol/",
+                            "type_info": {
+                              "description": "",
+                              "type": "identityref",
+                              "base": ["routing-protocol"]
+                            },
+                            "children": [],
+                            "name": "source-protocol",
+                            "description": "Type of the routing protocol from which the route\noriginated.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:active/",
+                            "type_info": {
+                              "description": "",
+                              "type": "empty"
+                            },
+                            "children": [],
+                            "name": "active",
+                            "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:last-updated/",
+                            "type_info": {
+                              "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                              "type": "yang:date-and-time"
+                            },
+                            "children": [],
+                            "name": "last-updated",
+                            "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "route",
+                        "description": "The active RIB route for the specified destination.\n\nIf no route exists in the RIB for the destination\naddress, no output is returned.\n\nAddress-family-specific modules MUST augment this\ncontainer with appropriate route contents.",
+                        "config": false,
+                        "class": "container",
+                        "status": "CURRENT"
+                      }],
+                      "name": "output",
+                      "description": "",
+                      "config": false,
+                      "class": "container",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "active-route",
+                  "description": "Return the active RIB route that is used for the\ndestination address.\n\nAddress-family-specific modules MUST augment input\nparameters with a leaf named 'destination-address'.",
+                  "class": "action",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:ribs/rt:rib/rt:name/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "name",
+                  "description": "The name of the RIB.\n\nFor system-controlled entries, the value of this leaf\nmust be the same as the name of the corresponding entry\nin the operational state.\n\nFor user-controlled entries, an arbitrary name can be\nused.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:ribs/rt:rib/rt:address-family/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["address-family"]
+                  },
+                  "children": [],
+                  "name": "address-family",
+                  "description": "Address family.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:ribs/rt:rib/rt:default-rib/",
+                  "type_info": {
+                    "default": "true",
+                    "description": "This flag has the value of 'true' if and only if the RIB\nis the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                    "type": "rt:default-rib"
+                  },
+                  "children": [],
+                  "name": "default-rib",
+                  "description": "This flag has the value of 'true' if and only if the RIB\nis the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:route-preference/",
+                        "type_info": {
+                          "description": "This type is used for route preferences.",
+                          "type": "rt:route-preference"
+                        },
+                        "children": [],
+                        "name": "route-preference",
+                        "description": "This route attribute, also known as 'administrative\ndistance', allows for selecting the preferred route\namong routes with the same destination prefix.  A\nsmaller value indicates a route that is\nmore preferred.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/",
+                          "type_info": {},
+                          "children": [
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                "type_info": {
+                                  "description": "This type is used by data models that need to reference\ninterfaces.",
+                                  "type": "if:interface-ref"
+                                },
+                                "children": [],
+                                "name": "outgoing-interface",
+                                "description": "Name of the outgoing interface.",
+                                "config": false,
+                                "class": "leaf",
+                                "status": "CURRENT"
+                              }],
+                              "name": "simple-next-hop",
+                              "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
+                              "config": false,
+                              "class": "case",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                "type_info": {
+                                  "description": "",
+                                  "type": "rt:enumeration"
+                                },
+                                "children": [],
+                                "name": "special-next-hop",
+                                "description": "Options for special next hops.",
+                                "config": false,
+                                "class": "leaf",
+                                "status": "CURRENT"
+                              }],
+                              "name": "special-next-hop",
+                              "description": "",
+                              "config": false,
+                              "class": "case",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                "type_info": {},
+                                "children": [{
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                    "type_info": {
+                                      "description": "This type is used by data models that need to reference\ninterfaces.",
+                                      "type": "if:interface-ref"
+                                    },
+                                    "children": [],
+                                    "name": "outgoing-interface",
+                                    "description": "Name of the outgoing interface.",
+                                    "config": false,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "next-hop",
+                                  "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
+                                  "config": false,
+                                  "class": "list",
+                                  "status": "CURRENT"
+                                }],
+                                "name": "next-hop-list",
+                                "description": "Container for multiple next hops.",
+                                "config": false,
+                                "class": "container",
+                                "status": "CURRENT"
+                              }],
+                              "name": "next-hop-list",
+                              "description": "",
+                              "config": false,
+                              "class": "case",
+                              "status": "CURRENT"
+                            }
+                          ],
+                          "name": "next-hop-options",
+                          "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
+                          "config": false,
+                          "class": "choice",
+                          "status": "CURRENT"
+                        }],
+                        "name": "next-hop",
+                        "description": "Route's next-hop attribute.",
+                        "config": false,
+                        "class": "container",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:source-protocol/",
+                        "type_info": {
+                          "description": "",
+                          "type": "identityref",
+                          "base": ["routing-protocol"]
+                        },
+                        "children": [],
+                        "name": "source-protocol",
+                        "description": "Type of the routing protocol from which the route\noriginated.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:active/",
+                        "type_info": {
+                          "description": "",
+                          "type": "empty"
+                        },
+                        "children": [],
+                        "name": "active",
+                        "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:last-updated/",
+                        "type_info": {
+                          "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                          "type": "yang:date-and-time"
+                        },
+                        "children": [],
+                        "name": "last-updated",
+                        "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "route",
+                    "description": "A RIB route entry.  This data node MUST be augmented\nwith information specific to routes of each address\nfamily.",
+                    "config": false,
+                    "class": "list",
+                    "status": "CURRENT"
+                  }],
+                  "name": "routes",
+                  "description": "Current contents of the RIB.",
+                  "config": false,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing/rt:ribs/rt:rib/rt:description/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "description",
+                  "description": "Textual description of the RIB.",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "rib",
+              "description": "Each entry contains a configuration for a RIB identified\nby the 'name' key.\n\nEntries having the same key as a system-controlled entry\nin the list '/routing/ribs/rib' are used for\nconfiguring parameters of that entry.  Other entries\ndefine additional user-controlled RIBs.",
+              "config": true,
+              "class": "list",
+              "status": "CURRENT"
+            }],
+            "name": "ribs",
+            "description": "Support for RIBs.",
+            "config": true,
+            "class": "container",
+            "status": "CURRENT"
+          }
+        ],
+        "name": "routing",
+        "description": "Configuration parameters for the routing subsystem.",
+        "config": true,
+        "class": "container",
+        "status": "CURRENT"
+      },
+      {
+        "path": "/rt:routing-state/",
+        "type_info": {},
+        "children": [
+          {
+            "path": "/rt:routing-state/rt:router-id/",
+            "type_info": {
+              "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
+              "type": "yang:dotted-quad"
+            },
+            "children": [],
+            "name": "router-id",
+            "description": "A 32-bit number in the form of a dotted quad that is used by\nsome routing protocols identifying a router.",
+            "config": false,
+            "class": "leaf",
+            "status": "CURRENT"
+          },
+          {
+            "path": "/rt:routing-state/rt:interfaces/",
+            "type_info": {},
+            "children": [{
+              "path": "/rt:routing-state/rt:interfaces/rt:interface/",
+              "type_info": {
+                "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
+                "type": "if:interface-state-ref"
+              },
+              "children": [],
+              "name": "interface",
+              "description": "Each entry is a reference to the name of a configured\nnetwork-layer interface.",
+              "config": false,
+              "class": "leaf-list",
+              "status": "OBSOLETE"
+            }],
+            "name": "interfaces",
+            "description": "Network-layer interfaces used for routing.",
+            "config": false,
+            "class": "container",
+            "status": "OBSOLETE"
+          },
+          {
+            "path": "/rt:routing-state/rt:control-plane-protocols/",
+            "type_info": {},
+            "children": [{
+              "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/rt:type/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["control-plane-protocol"]
+                  },
+                  "children": [],
+                  "name": "type",
+                  "description": "Type of the control-plane protocol.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "OBSOLETE"
+                },
+                {
+                  "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/rt:name/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "name",
+                  "description": "The name of the control-plane protocol instance.\n\nFor system-controlled instances, this name is\npersistent, i.e., it SHOULD NOT change across\nreboots.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "OBSOLETE"
+                }
+              ],
+              "name": "control-plane-protocol",
+              "description": "State data of a control-plane protocol instance.\n\nAn implementation MUST provide exactly one\nsystem-controlled instance of the 'direct'\npseudo-protocol.  Instances of other control-plane\nprotocols MAY be created by configuration.",
+              "config": false,
+              "class": "list",
+              "status": "OBSOLETE"
+            }],
+            "name": "control-plane-protocols",
+            "description": "Container for the list of routing protocol instances.",
+            "config": false,
+            "class": "container",
+            "status": "OBSOLETE"
+          },
+          {
+            "path": "/rt:routing-state/rt:ribs/",
+            "type_info": {},
+            "children": [{
+              "path": "/rt:routing-state/rt:ribs/rt:rib/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/",
+                  "type_info": {},
+                  "children": [
+                    {
+                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:input/",
+                      "type_info": {},
+                      "name": "input",
+                      "description": "",
+                      "config": true,
+                      "class": "container",
+                      "status": "CURRENT"
+                    },
+                    {
+                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/",
+                      "type_info": {},
+                      "children": [{
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/",
+                        "type_info": {},
+                        "children": [
+                          {
+                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/",
+                            "type_info": {},
+                            "children": [{
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/",
+                              "type_info": {},
+                              "children": [
+                                {
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                    "type_info": {
+                                      "description": "This type is used by data models that need to reference\ninterfaces.",
+                                      "type": "if:interface-ref"
+                                    },
+                                    "children": [],
+                                    "name": "outgoing-interface",
+                                    "description": "Name of the outgoing interface.",
+                                    "config": false,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "simple-next-hop",
+                                  "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
+                                  "config": false,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                },
+                                {
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                    "type_info": {
+                                      "description": "",
+                                      "type": "rt:enumeration"
+                                    },
+                                    "children": [],
+                                    "name": "special-next-hop",
+                                    "description": "Options for special next hops.",
+                                    "config": false,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "special-next-hop",
+                                  "description": "",
+                                  "config": false,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                },
+                                {
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                      "type_info": {},
+                                      "children": [{
+                                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                        "type_info": {
+                                          "description": "This type is used by data models that need to reference\ninterfaces.",
+                                          "type": "if:interface-ref"
+                                        },
+                                        "children": [],
+                                        "name": "outgoing-interface",
+                                        "description": "Name of the outgoing interface.",
+                                        "config": false,
+                                        "class": "leaf",
+                                        "status": "CURRENT"
+                                      }],
+                                      "name": "next-hop",
+                                      "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
+                                      "config": false,
+                                      "class": "list",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "next-hop-list",
+                                    "description": "Container for multiple next hops.",
+                                    "config": false,
+                                    "class": "container",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "next-hop-list",
+                                  "description": "",
+                                  "config": false,
+                                  "class": "case",
+                                  "status": "CURRENT"
+                                }
+                              ],
+                              "name": "next-hop-options",
+                              "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
+                              "config": false,
+                              "class": "choice",
+                              "status": "CURRENT"
+                            }],
+                            "name": "next-hop",
+                            "description": "Route's next-hop attribute.",
+                            "config": false,
+                            "class": "container",
+                            "status": "OBSOLETE"
+                          },
+                          {
+                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:source-protocol/",
+                            "type_info": {
+                              "description": "",
+                              "type": "identityref",
+                              "base": ["routing-protocol"]
+                            },
+                            "children": [],
+                            "name": "source-protocol",
+                            "description": "Type of the routing protocol from which the route\noriginated.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:active/",
+                            "type_info": {
+                              "description": "",
+                              "type": "empty"
+                            },
+                            "children": [],
+                            "name": "active",
+                            "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          },
+                          {
+                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:last-updated/",
+                            "type_info": {
+                              "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                              "type": "yang:date-and-time"
+                            },
+                            "children": [],
+                            "name": "last-updated",
+                            "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
+                            "config": false,
+                            "class": "leaf",
+                            "status": "CURRENT"
+                          }
+                        ],
+                        "name": "route",
+                        "description": "The active RIB route for the specified\ndestination.\n\nIf no route exists in the RIB for the destination\naddress, no output is returned.\n\nAddress-family-specific modules MUST augment this\ncontainer with appropriate route contents.",
+                        "config": false,
+                        "class": "container",
+                        "status": "OBSOLETE"
+                      }],
+                      "name": "output",
+                      "description": "",
+                      "config": false,
+                      "class": "container",
+                      "status": "CURRENT"
+                    }
+                  ],
+                  "name": "active-route",
+                  "description": "Return the active RIB route that is used for the\ndestination address.\n\nAddress-family-specific modules MUST augment input\nparameters with a leaf named 'destination-address'.",
+                  "class": "action",
+                  "status": "OBSOLETE"
+                },
+                {
+                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:name/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "name",
+                  "description": "The name of the RIB.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "OBSOLETE"
+                },
+                {
+                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:address-family/",
+                  "type_info": {
+                    "description": "",
+                    "type": "identityref",
+                    "base": ["address-family"]
+                  },
+                  "children": [],
+                  "name": "address-family",
+                  "description": "Address family.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:default-rib/",
+                  "type_info": {
+                    "default": "true",
+                    "description": "This flag has the value of 'true' if and only if the\nRIB is the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                    "type": "rt:default-rib"
+                  },
+                  "children": [],
+                  "name": "default-rib",
+                  "description": "This flag has the value of 'true' if and only if the\nRIB is the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "OBSOLETE"
+                },
+                {
+                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:route-preference/",
+                        "type_info": {
+                          "description": "This type is used for route preferences.",
+                          "type": "rt:route-preference"
+                        },
+                        "children": [],
+                        "name": "route-preference",
+                        "description": "This route attribute, also known as 'administrative\ndistance', allows for selecting the preferred route\namong routes with the same destination prefix.  A\nsmaller value indicates a route that is\nmore preferred.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "OBSOLETE"
+                      },
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/",
+                          "type_info": {},
+                          "children": [
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                "type_info": {
+                                  "description": "This type is used by data models that need to reference\ninterfaces.",
+                                  "type": "if:interface-ref"
+                                },
+                                "children": [],
+                                "name": "outgoing-interface",
+                                "description": "Name of the outgoing interface.",
+                                "config": false,
+                                "class": "leaf",
+                                "status": "CURRENT"
+                              }],
+                              "name": "simple-next-hop",
+                              "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
+                              "config": false,
+                              "class": "case",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                "type_info": {
+                                  "description": "",
+                                  "type": "rt:enumeration"
+                                },
+                                "children": [],
+                                "name": "special-next-hop",
+                                "description": "Options for special next hops.",
+                                "config": false,
+                                "class": "leaf",
+                                "status": "CURRENT"
+                              }],
+                              "name": "special-next-hop",
+                              "description": "",
+                              "config": false,
+                              "class": "case",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                "type_info": {},
+                                "children": [{
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                  "type_info": {},
+                                  "children": [{
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                    "type_info": {
+                                      "description": "This type is used by data models that need to reference\ninterfaces.",
+                                      "type": "if:interface-ref"
+                                    },
+                                    "children": [],
+                                    "name": "outgoing-interface",
+                                    "description": "Name of the outgoing interface.",
+                                    "config": false,
+                                    "class": "leaf",
+                                    "status": "CURRENT"
+                                  }],
+                                  "name": "next-hop",
+                                  "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
+                                  "config": false,
+                                  "class": "list",
+                                  "status": "CURRENT"
+                                }],
+                                "name": "next-hop-list",
+                                "description": "Container for multiple next hops.",
+                                "config": false,
+                                "class": "container",
+                                "status": "CURRENT"
+                              }],
+                              "name": "next-hop-list",
+                              "description": "",
+                              "config": false,
+                              "class": "case",
+                              "status": "CURRENT"
+                            }
+                          ],
+                          "name": "next-hop-options",
+                          "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
+                          "config": false,
+                          "class": "choice",
+                          "status": "CURRENT"
+                        }],
+                        "name": "next-hop",
+                        "description": "Route's next-hop attribute.",
+                        "config": false,
+                        "class": "container",
+                        "status": "OBSOLETE"
+                      },
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:source-protocol/",
+                        "type_info": {
+                          "description": "",
+                          "type": "identityref",
+                          "base": ["routing-protocol"]
+                        },
+                        "children": [],
+                        "name": "source-protocol",
+                        "description": "Type of the routing protocol from which the route\noriginated.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:active/",
+                        "type_info": {
+                          "description": "",
+                          "type": "empty"
+                        },
+                        "children": [],
+                        "name": "active",
+                        "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:last-updated/",
+                        "type_info": {
+                          "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                          "type": "yang:date-and-time"
+                        },
+                        "children": [],
+                        "name": "last-updated",
+                        "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
+                        "config": false,
+                        "class": "leaf",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "route",
+                    "description": "A RIB route entry.  This data node MUST be augmented\nwith information specific to routes of each address\nfamily.",
+                    "config": false,
+                    "class": "list",
+                    "status": "OBSOLETE"
+                  }],
+                  "name": "routes",
+                  "description": "Current contents of the RIB.",
+                  "config": false,
+                  "class": "container",
+                  "status": "OBSOLETE"
+                }
+              ],
+              "name": "rib",
+              "description": "Each entry represents a RIB identified by the 'name'\nkey.  All routes in a RIB MUST belong to the same address\nfamily.\n\nAn implementation SHOULD provide one system-controlled\ndefault RIB for each supported address family.",
+              "config": false,
+              "class": "list",
+              "status": "OBSOLETE"
+            }],
+            "name": "ribs",
+            "description": "Container for RIBs.",
+            "config": false,
+            "class": "container",
+            "status": "OBSOLETE"
+          }
+        ],
+        "name": "routing-state",
+        "description": "State data of the routing subsystem.",
+        "config": false,
+        "class": "container",
+        "status": "OBSOLETE"
+      }
+    ],
+    "module": {
+      "prefix": "rt",
+      "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:rtgwg@ietf.org>\n\nEditor:   Ladislav Lhotka\n          <mailto:lhotka@nic.cz>\n          Acee Lindem\n          <mailto:acee@cisco.com>\n          Yingzhen Qu\n          <mailto:yingzhen.qu@huawei.com>",
+      "name": "ietf-routing",
+      "namespace": "urn:ietf:params:xml:ns:yang:ietf-routing",
+      "description": "This YANG module defines essential components for the management\nof a routing subsystem.  The model fully conforms to the Network\nManagement Datastore Architecture (NMDA).\n\nCopyright (c) 2018 IETF Trust and the persons\nidentified as authors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\nThis version of this YANG module is part of RFC 8349; see\nthe RFC itself for full legal notices.",
+      "revision": "2018-03-13"
+    }
+  }
+]}

--- a/src/test/resources/out/compare/routing.json
+++ b/src/test/resources/out/compare/routing.json
@@ -1,152 +1,378 @@
 {
-  "children": [
+  "parsed-models": [
     {
-      "path": "/rt:routing/",
-      "type_info": {},
       "children": [
         {
-          "path": "/rt:routing/rt:router-id/",
-          "type_info": {
-            "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
-            "type": "yang:dotted-quad"
-          },
-          "children": [],
-          "name": "router-id",
-          "description": "A 32-bit number in the form of a dotted quad that is used by\nsome routing protocols identifying a router.",
-          "config": true,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/rt:routing/rt:interfaces/",
+          "path": "/rt:routing/",
           "type_info": {},
-          "children": [{
-            "path": "/rt:routing/rt:interfaces/rt:interface/",
-            "type_info": {
-              "description": "This type is used by data models that need to reference\ninterfaces.",
-              "type": "if:interface-ref"
+          "children": [
+            {
+              "path": "/rt:routing/rt:router-id/",
+              "type_info": {
+                "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
+                "type": "yang:dotted-quad"
+              },
+              "children": [],
+              "name": "router-id",
+              "description": "A 32-bit number in the form of a dotted quad that is used by\nsome routing protocols identifying a router.",
+              "config": true,
+              "class": "leaf",
+              "status": "CURRENT"
             },
-            "children": [],
-            "name": "interface",
-            "description": "Each entry is a reference to the name of a configured\nnetwork-layer interface.",
-            "config": false,
-            "class": "leaf-list",
-            "status": "CURRENT"
-          }],
-          "name": "interfaces",
-          "description": "Network-layer interfaces used for routing.",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/rt:routing/rt:control-plane-protocols/",
-          "type_info": {},
-          "children": [{
-            "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/",
-            "type_info": {},
-            "children": [
-              {
-                "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:type/",
+            {
+              "path": "/rt:routing/rt:interfaces/",
+              "type_info": {},
+              "children": [{
+                "path": "/rt:routing/rt:interfaces/rt:interface/",
                 "type_info": {
-                  "description": "",
-                  "type": "identityref",
-                  "base": ["control-plane-protocol"]
+                  "description": "This type is used by data models that need to reference\ninterfaces.",
+                  "type": "if:interface-ref"
                 },
                 "children": [],
-                "name": "type",
-                "description": "Type of the control-plane protocol -- an identity\nderived from the 'control-plane-protocol'\nbase identity.",
-                "config": true,
-                "class": "leaf",
+                "name": "interface",
+                "description": "Each entry is a reference to the name of a configured\nnetwork-layer interface.",
+                "config": false,
+                "class": "leaf-list",
                 "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:name/",
-                "type_info": {
-                  "description": "",
-                  "type": "string"
-                },
-                "children": [],
-                "name": "name",
-                "description": "An arbitrary name of the control-plane protocol\ninstance.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:description/",
-                "type_info": {
-                  "description": "",
-                  "type": "string"
-                },
-                "children": [],
-                "name": "description",
-                "description": "Textual description of the control-plane protocol\ninstance.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:static-routes/",
-                "type_info": {},
-                "name": "static-routes",
-                "description": "Support for the 'static' pseudo-protocol.\n\nAddress-family-specific modules augment this node with\ntheir lists of routes.",
-                "config": true,
-                "class": "container",
-                "status": "CURRENT"
-              }
-            ],
-            "name": "control-plane-protocol",
-            "description": "Each entry contains a control-plane protocol instance.",
-            "config": true,
-            "class": "list",
-            "status": "CURRENT"
-          }],
-          "name": "control-plane-protocols",
-          "description": "Support for control-plane protocol instances.",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/rt:routing/rt:ribs/",
-          "type_info": {},
-          "children": [{
-            "path": "/rt:routing/rt:ribs/rt:rib/",
-            "type_info": {},
-            "children": [
-              {
-                "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/",
+              }],
+              "name": "interfaces",
+              "description": "Network-layer interfaces used for routing.",
+              "config": false,
+              "class": "container",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/rt:routing/rt:control-plane-protocols/",
+              "type_info": {},
+              "children": [{
+                "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/",
                 "type_info": {},
                 "children": [
                   {
-                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:input/",
-                    "type_info": {},
-                    "name": "input",
-                    "description": "",
+                    "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:type/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["control-plane-protocol"]
+                    },
+                    "children": [],
+                    "name": "type",
+                    "description": "Type of the control-plane protocol -- an identity\nderived from the 'control-plane-protocol'\nbase identity.",
                     "config": true,
-                    "class": "container",
+                    "class": "leaf",
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/",
+                    "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:name/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "name",
+                    "description": "An arbitrary name of the control-plane protocol\ninstance.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:description/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "description",
+                    "description": "Textual description of the control-plane protocol\ninstance.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing/rt:control-plane-protocols/rt:control-plane-protocol/rt:static-routes/",
+                    "type_info": {},
+                    "name": "static-routes",
+                    "description": "Support for the 'static' pseudo-protocol.\n\nAddress-family-specific modules augment this node with\ntheir lists of routes.",
+                    "config": true,
+                    "class": "container",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "control-plane-protocol",
+                "description": "Each entry contains a control-plane protocol instance.",
+                "config": true,
+                "class": "list",
+                "status": "CURRENT"
+              }],
+              "name": "control-plane-protocols",
+              "description": "Support for control-plane protocol instances.",
+              "config": true,
+              "class": "container",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/rt:routing/rt:ribs/",
+              "type_info": {},
+              "children": [{
+                "path": "/rt:routing/rt:ribs/rt:rib/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:input/",
+                        "type_info": {},
+                        "name": "input",
+                        "description": "",
+                        "config": true,
+                        "class": "container",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/",
+                          "type_info": {},
+                          "children": [
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/",
+                                "type_info": {},
+                                "children": [
+                                  {
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                      "type_info": {
+                                        "description": "This type is used by data models that need to reference\ninterfaces.",
+                                        "type": "if:interface-ref"
+                                      },
+                                      "children": [],
+                                      "name": "outgoing-interface",
+                                      "description": "Name of the outgoing interface.",
+                                      "config": false,
+                                      "class": "leaf",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "simple-next-hop",
+                                    "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
+                                    "config": false,
+                                    "class": "case",
+                                    "status": "CURRENT"
+                                  },
+                                  {
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                      "type_info": {
+                                        "description": "",
+                                        "type": "rt:enumeration"
+                                      },
+                                      "children": [],
+                                      "name": "special-next-hop",
+                                      "description": "Options for special next hops.",
+                                      "config": false,
+                                      "class": "leaf",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "special-next-hop",
+                                    "description": "",
+                                    "config": false,
+                                    "class": "case",
+                                    "status": "CURRENT"
+                                  },
+                                  {
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                      "type_info": {},
+                                      "children": [{
+                                        "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                        "type_info": {},
+                                        "children": [{
+                                          "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                          "type_info": {
+                                            "description": "This type is used by data models that need to reference\ninterfaces.",
+                                            "type": "if:interface-ref"
+                                          },
+                                          "children": [],
+                                          "name": "outgoing-interface",
+                                          "description": "Name of the outgoing interface.",
+                                          "config": false,
+                                          "class": "leaf",
+                                          "status": "CURRENT"
+                                        }],
+                                        "name": "next-hop",
+                                        "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
+                                        "config": false,
+                                        "class": "list",
+                                        "status": "CURRENT"
+                                      }],
+                                      "name": "next-hop-list",
+                                      "description": "Container for multiple next hops.",
+                                      "config": false,
+                                      "class": "container",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "next-hop-list",
+                                    "description": "",
+                                    "config": false,
+                                    "class": "case",
+                                    "status": "CURRENT"
+                                  }
+                                ],
+                                "name": "next-hop-options",
+                                "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
+                                "config": false,
+                                "class": "choice",
+                                "status": "CURRENT"
+                              }],
+                              "name": "next-hop",
+                              "description": "Route's next-hop attribute.",
+                              "config": false,
+                              "class": "container",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:source-protocol/",
+                              "type_info": {
+                                "description": "",
+                                "type": "identityref",
+                                "base": ["routing-protocol"]
+                              },
+                              "children": [],
+                              "name": "source-protocol",
+                              "description": "Type of the routing protocol from which the route\noriginated.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:active/",
+                              "type_info": {
+                                "description": "",
+                                "type": "empty"
+                              },
+                              "children": [],
+                              "name": "active",
+                              "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:last-updated/",
+                              "type_info": {
+                                "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                                "type": "yang:date-and-time"
+                              },
+                              "children": [],
+                              "name": "last-updated",
+                              "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }
+                          ],
+                          "name": "route",
+                          "description": "The active RIB route for the specified destination.\n\nIf no route exists in the RIB for the destination\naddress, no output is returned.\n\nAddress-family-specific modules MUST augment this\ncontainer with appropriate route contents.",
+                          "config": false,
+                          "class": "container",
+                          "status": "CURRENT"
+                        }],
+                        "name": "output",
+                        "description": "",
+                        "config": false,
+                        "class": "container",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "active-route",
+                    "description": "Return the active RIB route that is used for the\ndestination address.\n\nAddress-family-specific modules MUST augment input\nparameters with a leaf named 'destination-address'.",
+                    "class": "action",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:name/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "name",
+                    "description": "The name of the RIB.\n\nFor system-controlled entries, the value of this leaf\nmust be the same as the name of the corresponding entry\nin the operational state.\n\nFor user-controlled entries, an arbitrary name can be\nused.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:address-family/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["address-family"]
+                    },
+                    "children": [],
+                    "name": "address-family",
+                    "description": "Address family.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:default-rib/",
+                    "type_info": {
+                      "default": "true",
+                      "description": "This flag has the value of 'true' if and only if the RIB\nis the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                      "type": "rt:default-rib"
+                    },
+                    "children": [],
+                    "name": "default-rib",
+                    "description": "This flag has the value of 'true' if and only if the RIB\nis the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/",
                     "type_info": {},
                     "children": [{
-                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/",
+                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/",
                       "type_info": {},
                       "children": [
                         {
-                          "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/",
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:route-preference/",
+                          "type_info": {
+                            "description": "This type is used for route preferences.",
+                            "type": "rt:route-preference"
+                          },
+                          "children": [],
+                          "name": "route-preference",
+                          "description": "This route attribute, also known as 'administrative\ndistance', allows for selecting the preferred route\namong routes with the same destination prefix.  A\nsmaller value indicates a route that is\nmore preferred.",
+                          "config": false,
+                          "class": "leaf",
+                          "status": "CURRENT"
+                        },
+                        {
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/",
                           "type_info": {},
                           "children": [{
-                            "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/",
+                            "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/",
                             "type_info": {},
                             "children": [
                               {
-                                "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
                                 "type_info": {},
                                 "children": [{
-                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
                                   "type_info": {
                                     "description": "This type is used by data models that need to reference\ninterfaces.",
                                     "type": "if:interface-ref"
@@ -165,10 +391,10 @@
                                 "status": "CURRENT"
                               },
                               {
-                                "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
                                 "type_info": {},
                                 "children": [{
-                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
                                   "type_info": {
                                     "description": "",
                                     "type": "rt:enumeration"
@@ -187,16 +413,16 @@
                                 "status": "CURRENT"
                               },
                               {
-                                "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
                                 "type_info": {},
                                 "children": [{
-                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
                                   "type_info": {},
                                   "children": [{
-                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                    "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
                                     "type_info": {},
                                     "children": [{
-                                      "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
                                       "type_info": {
                                         "description": "This type is used by data models that need to reference\ninterfaces.",
                                         "type": "if:interface-ref"
@@ -240,7 +466,7 @@
                           "status": "CURRENT"
                         },
                         {
-                          "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:source-protocol/",
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:source-protocol/",
                           "type_info": {
                             "description": "",
                             "type": "identityref",
@@ -254,7 +480,7 @@
                           "status": "CURRENT"
                         },
                         {
-                          "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:active/",
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:active/",
                           "type_info": {
                             "description": "",
                             "type": "empty"
@@ -267,7 +493,7 @@
                           "status": "CURRENT"
                         },
                         {
-                          "path": "/rt:routing/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:last-updated/",
+                          "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:last-updated/",
                           "type_info": {
                             "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
                             "type": "yang:date-and-time"
@@ -281,399 +507,399 @@
                         }
                       ],
                       "name": "route",
-                      "description": "The active RIB route for the specified destination.\n\nIf no route exists in the RIB for the destination\naddress, no output is returned.\n\nAddress-family-specific modules MUST augment this\ncontainer with appropriate route contents.",
+                      "description": "A RIB route entry.  This data node MUST be augmented\nwith information specific to routes of each address\nfamily.",
                       "config": false,
-                      "class": "container",
+                      "class": "list",
                       "status": "CURRENT"
                     }],
-                    "name": "output",
-                    "description": "",
+                    "name": "routes",
+                    "description": "Current contents of the RIB.",
                     "config": false,
-                    "class": "container",
-                    "status": "CURRENT"
-                  }
-                ],
-                "name": "active-route",
-                "description": "Return the active RIB route that is used for the\ndestination address.\n\nAddress-family-specific modules MUST augment input\nparameters with a leaf named 'destination-address'.",
-                "class": "action",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:ribs/rt:rib/rt:name/",
-                "type_info": {
-                  "description": "",
-                  "type": "string"
-                },
-                "children": [],
-                "name": "name",
-                "description": "The name of the RIB.\n\nFor system-controlled entries, the value of this leaf\nmust be the same as the name of the corresponding entry\nin the operational state.\n\nFor user-controlled entries, an arbitrary name can be\nused.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:ribs/rt:rib/rt:address-family/",
-                "type_info": {
-                  "description": "",
-                  "type": "identityref",
-                  "base": ["address-family"]
-                },
-                "children": [],
-                "name": "address-family",
-                "description": "Address family.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:ribs/rt:rib/rt:default-rib/",
-                "type_info": {
-                  "default": "true",
-                  "description": "This flag has the value of 'true' if and only if the RIB\nis the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
-                  "type": "rt:default-rib"
-                },
-                "children": [],
-                "name": "default-rib",
-                "description": "This flag has the value of 'true' if and only if the RIB\nis the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/",
-                "type_info": {},
-                "children": [{
-                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/",
-                  "type_info": {},
-                  "children": [
-                    {
-                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:route-preference/",
-                      "type_info": {
-                        "description": "This type is used for route preferences.",
-                        "type": "rt:route-preference"
-                      },
-                      "children": [],
-                      "name": "route-preference",
-                      "description": "This route attribute, also known as 'administrative\ndistance', allows for selecting the preferred route\namong routes with the same destination prefix.  A\nsmaller value indicates a route that is\nmore preferred.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/",
-                        "type_info": {},
-                        "children": [
-                          {
-                            "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
-                              "type_info": {
-                                "description": "This type is used by data models that need to reference\ninterfaces.",
-                                "type": "if:interface-ref"
-                              },
-                              "children": [],
-                              "name": "outgoing-interface",
-                              "description": "Name of the outgoing interface.",
-                              "config": false,
-                              "class": "leaf",
-                              "status": "CURRENT"
-                            }],
-                            "name": "simple-next-hop",
-                            "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
-                            "config": false,
-                            "class": "case",
-                            "status": "CURRENT"
-                          },
-                          {
-                            "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
-                              "type_info": {
-                                "description": "",
-                                "type": "rt:enumeration"
-                              },
-                              "children": [],
-                              "name": "special-next-hop",
-                              "description": "Options for special next hops.",
-                              "config": false,
-                              "class": "leaf",
-                              "status": "CURRENT"
-                            }],
-                            "name": "special-next-hop",
-                            "description": "",
-                            "config": false,
-                            "class": "case",
-                            "status": "CURRENT"
-                          },
-                          {
-                            "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
-                              "type_info": {},
-                              "children": [{
-                                "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
-                                "type_info": {},
-                                "children": [{
-                                  "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
-                                  "type_info": {
-                                    "description": "This type is used by data models that need to reference\ninterfaces.",
-                                    "type": "if:interface-ref"
-                                  },
-                                  "children": [],
-                                  "name": "outgoing-interface",
-                                  "description": "Name of the outgoing interface.",
-                                  "config": false,
-                                  "class": "leaf",
-                                  "status": "CURRENT"
-                                }],
-                                "name": "next-hop",
-                                "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
-                                "config": false,
-                                "class": "list",
-                                "status": "CURRENT"
-                              }],
-                              "name": "next-hop-list",
-                              "description": "Container for multiple next hops.",
-                              "config": false,
-                              "class": "container",
-                              "status": "CURRENT"
-                            }],
-                            "name": "next-hop-list",
-                            "description": "",
-                            "config": false,
-                            "class": "case",
-                            "status": "CURRENT"
-                          }
-                        ],
-                        "name": "next-hop-options",
-                        "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
-                        "config": false,
-                        "class": "choice",
-                        "status": "CURRENT"
-                      }],
-                      "name": "next-hop",
-                      "description": "Route's next-hop attribute.",
-                      "config": false,
-                      "class": "container",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:source-protocol/",
-                      "type_info": {
-                        "description": "",
-                        "type": "identityref",
-                        "base": ["routing-protocol"]
-                      },
-                      "children": [],
-                      "name": "source-protocol",
-                      "description": "Type of the routing protocol from which the route\noriginated.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:active/",
-                      "type_info": {
-                        "description": "",
-                        "type": "empty"
-                      },
-                      "children": [],
-                      "name": "active",
-                      "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/rt:routing/rt:ribs/rt:rib/rt:routes/rt:route/rt:last-updated/",
-                      "type_info": {
-                        "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
-                        "type": "yang:date-and-time"
-                      },
-                      "children": [],
-                      "name": "last-updated",
-                      "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    }
-                  ],
-                  "name": "route",
-                  "description": "A RIB route entry.  This data node MUST be augmented\nwith information specific to routes of each address\nfamily.",
-                  "config": false,
-                  "class": "list",
-                  "status": "CURRENT"
-                }],
-                "name": "routes",
-                "description": "Current contents of the RIB.",
-                "config": false,
-                "class": "container",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing/rt:ribs/rt:rib/rt:description/",
-                "type_info": {
-                  "description": "",
-                  "type": "string"
-                },
-                "children": [],
-                "name": "description",
-                "description": "Textual description of the RIB.",
-                "config": true,
-                "class": "leaf",
-                "status": "CURRENT"
-              }
-            ],
-            "name": "rib",
-            "description": "Each entry contains a configuration for a RIB identified\nby the 'name' key.\n\nEntries having the same key as a system-controlled entry\nin the list '/routing/ribs/rib' are used for\nconfiguring parameters of that entry.  Other entries\ndefine additional user-controlled RIBs.",
-            "config": true,
-            "class": "list",
-            "status": "CURRENT"
-          }],
-          "name": "ribs",
-          "description": "Support for RIBs.",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "routing",
-      "description": "Configuration parameters for the routing subsystem.",
-      "config": true,
-      "class": "container",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/rt:routing-state/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/rt:routing-state/rt:router-id/",
-          "type_info": {
-            "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
-            "type": "yang:dotted-quad"
-          },
-          "children": [],
-          "name": "router-id",
-          "description": "A 32-bit number in the form of a dotted quad that is used by\nsome routing protocols identifying a router.",
-          "config": false,
-          "class": "leaf",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/rt:routing-state/rt:interfaces/",
-          "type_info": {},
-          "children": [{
-            "path": "/rt:routing-state/rt:interfaces/rt:interface/",
-            "type_info": {
-              "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
-              "type": "if:interface-state-ref"
-            },
-            "children": [],
-            "name": "interface",
-            "description": "Each entry is a reference to the name of a configured\nnetwork-layer interface.",
-            "config": false,
-            "class": "leaf-list",
-            "status": "OBSOLETE"
-          }],
-          "name": "interfaces",
-          "description": "Network-layer interfaces used for routing.",
-          "config": false,
-          "class": "container",
-          "status": "OBSOLETE"
-        },
-        {
-          "path": "/rt:routing-state/rt:control-plane-protocols/",
-          "type_info": {},
-          "children": [{
-            "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/",
-            "type_info": {},
-            "children": [
-              {
-                "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/rt:type/",
-                "type_info": {
-                  "description": "",
-                  "type": "identityref",
-                  "base": ["control-plane-protocol"]
-                },
-                "children": [],
-                "name": "type",
-                "description": "Type of the control-plane protocol.",
-                "config": false,
-                "class": "leaf",
-                "status": "OBSOLETE"
-              },
-              {
-                "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/rt:name/",
-                "type_info": {
-                  "description": "",
-                  "type": "string"
-                },
-                "children": [],
-                "name": "name",
-                "description": "The name of the control-plane protocol instance.\n\nFor system-controlled instances, this name is\npersistent, i.e., it SHOULD NOT change across\nreboots.",
-                "config": false,
-                "class": "leaf",
-                "status": "OBSOLETE"
-              }
-            ],
-            "name": "control-plane-protocol",
-            "description": "State data of a control-plane protocol instance.\n\nAn implementation MUST provide exactly one\nsystem-controlled instance of the 'direct'\npseudo-protocol.  Instances of other control-plane\nprotocols MAY be created by configuration.",
-            "config": false,
-            "class": "list",
-            "status": "OBSOLETE"
-          }],
-          "name": "control-plane-protocols",
-          "description": "Container for the list of routing protocol instances.",
-          "config": false,
-          "class": "container",
-          "status": "OBSOLETE"
-        },
-        {
-          "path": "/rt:routing-state/rt:ribs/",
-          "type_info": {},
-          "children": [{
-            "path": "/rt:routing-state/rt:ribs/rt:rib/",
-            "type_info": {},
-            "children": [
-              {
-                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/",
-                "type_info": {},
-                "children": [
-                  {
-                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:input/",
-                    "type_info": {},
-                    "name": "input",
-                    "description": "",
-                    "config": true,
                     "class": "container",
                     "status": "CURRENT"
                   },
                   {
-                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/",
+                    "path": "/rt:routing/rt:ribs/rt:rib/rt:description/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "description",
+                    "description": "Textual description of the RIB.",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }
+                ],
+                "name": "rib",
+                "description": "Each entry contains a configuration for a RIB identified\nby the 'name' key.\n\nEntries having the same key as a system-controlled entry\nin the list '/routing/ribs/rib' are used for\nconfiguring parameters of that entry.  Other entries\ndefine additional user-controlled RIBs.",
+                "config": true,
+                "class": "list",
+                "status": "CURRENT"
+              }],
+              "name": "ribs",
+              "description": "Support for RIBs.",
+              "config": true,
+              "class": "container",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "routing",
+          "description": "Configuration parameters for the routing subsystem.",
+          "config": true,
+          "class": "container",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/rt:routing-state/",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/rt:routing-state/rt:router-id/",
+              "type_info": {
+                "description": "An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.",
+                "type": "yang:dotted-quad"
+              },
+              "children": [],
+              "name": "router-id",
+              "description": "A 32-bit number in the form of a dotted quad that is used by\nsome routing protocols identifying a router.",
+              "config": false,
+              "class": "leaf",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/rt:routing-state/rt:interfaces/",
+              "type_info": {},
+              "children": [{
+                "path": "/rt:routing-state/rt:interfaces/rt:interface/",
+                "type_info": {
+                  "description": "This type is used by data models that need to reference\nthe operationally present interfaces.",
+                  "type": "if:interface-state-ref"
+                },
+                "children": [],
+                "name": "interface",
+                "description": "Each entry is a reference to the name of a configured\nnetwork-layer interface.",
+                "config": false,
+                "class": "leaf-list",
+                "status": "OBSOLETE"
+              }],
+              "name": "interfaces",
+              "description": "Network-layer interfaces used for routing.",
+              "config": false,
+              "class": "container",
+              "status": "OBSOLETE"
+            },
+            {
+              "path": "/rt:routing-state/rt:control-plane-protocols/",
+              "type_info": {},
+              "children": [{
+                "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/rt:type/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["control-plane-protocol"]
+                    },
+                    "children": [],
+                    "name": "type",
+                    "description": "Type of the control-plane protocol.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "OBSOLETE"
+                  },
+                  {
+                    "path": "/rt:routing-state/rt:control-plane-protocols/rt:control-plane-protocol/rt:name/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "name",
+                    "description": "The name of the control-plane protocol instance.\n\nFor system-controlled instances, this name is\npersistent, i.e., it SHOULD NOT change across\nreboots.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "OBSOLETE"
+                  }
+                ],
+                "name": "control-plane-protocol",
+                "description": "State data of a control-plane protocol instance.\n\nAn implementation MUST provide exactly one\nsystem-controlled instance of the 'direct'\npseudo-protocol.  Instances of other control-plane\nprotocols MAY be created by configuration.",
+                "config": false,
+                "class": "list",
+                "status": "OBSOLETE"
+              }],
+              "name": "control-plane-protocols",
+              "description": "Container for the list of routing protocol instances.",
+              "config": false,
+              "class": "container",
+              "status": "OBSOLETE"
+            },
+            {
+              "path": "/rt:routing-state/rt:ribs/",
+              "type_info": {},
+              "children": [{
+                "path": "/rt:routing-state/rt:ribs/rt:rib/",
+                "type_info": {},
+                "children": [
+                  {
+                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/",
+                    "type_info": {},
+                    "children": [
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:input/",
+                        "type_info": {},
+                        "name": "input",
+                        "description": "",
+                        "config": true,
+                        "class": "container",
+                        "status": "CURRENT"
+                      },
+                      {
+                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/",
+                        "type_info": {},
+                        "children": [{
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/",
+                          "type_info": {},
+                          "children": [
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/",
+                              "type_info": {},
+                              "children": [{
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/",
+                                "type_info": {},
+                                "children": [
+                                  {
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                      "type_info": {
+                                        "description": "This type is used by data models that need to reference\ninterfaces.",
+                                        "type": "if:interface-ref"
+                                      },
+                                      "children": [],
+                                      "name": "outgoing-interface",
+                                      "description": "Name of the outgoing interface.",
+                                      "config": false,
+                                      "class": "leaf",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "simple-next-hop",
+                                    "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
+                                    "config": false,
+                                    "class": "case",
+                                    "status": "CURRENT"
+                                  },
+                                  {
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                      "type_info": {
+                                        "description": "",
+                                        "type": "rt:enumeration"
+                                      },
+                                      "children": [],
+                                      "name": "special-next-hop",
+                                      "description": "Options for special next hops.",
+                                      "config": false,
+                                      "class": "leaf",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "special-next-hop",
+                                    "description": "",
+                                    "config": false,
+                                    "class": "case",
+                                    "status": "CURRENT"
+                                  },
+                                  {
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                                    "type_info": {},
+                                    "children": [{
+                                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                      "type_info": {},
+                                      "children": [{
+                                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                        "type_info": {},
+                                        "children": [{
+                                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                          "type_info": {
+                                            "description": "This type is used by data models that need to reference\ninterfaces.",
+                                            "type": "if:interface-ref"
+                                          },
+                                          "children": [],
+                                          "name": "outgoing-interface",
+                                          "description": "Name of the outgoing interface.",
+                                          "config": false,
+                                          "class": "leaf",
+                                          "status": "CURRENT"
+                                        }],
+                                        "name": "next-hop",
+                                        "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
+                                        "config": false,
+                                        "class": "list",
+                                        "status": "CURRENT"
+                                      }],
+                                      "name": "next-hop-list",
+                                      "description": "Container for multiple next hops.",
+                                      "config": false,
+                                      "class": "container",
+                                      "status": "CURRENT"
+                                    }],
+                                    "name": "next-hop-list",
+                                    "description": "",
+                                    "config": false,
+                                    "class": "case",
+                                    "status": "CURRENT"
+                                  }
+                                ],
+                                "name": "next-hop-options",
+                                "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
+                                "config": false,
+                                "class": "choice",
+                                "status": "CURRENT"
+                              }],
+                              "name": "next-hop",
+                              "description": "Route's next-hop attribute.",
+                              "config": false,
+                              "class": "container",
+                              "status": "OBSOLETE"
+                            },
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:source-protocol/",
+                              "type_info": {
+                                "description": "",
+                                "type": "identityref",
+                                "base": ["routing-protocol"]
+                              },
+                              "children": [],
+                              "name": "source-protocol",
+                              "description": "Type of the routing protocol from which the route\noriginated.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:active/",
+                              "type_info": {
+                                "description": "",
+                                "type": "empty"
+                              },
+                              "children": [],
+                              "name": "active",
+                              "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            },
+                            {
+                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:last-updated/",
+                              "type_info": {
+                                "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
+                                "type": "yang:date-and-time"
+                              },
+                              "children": [],
+                              "name": "last-updated",
+                              "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
+                              "config": false,
+                              "class": "leaf",
+                              "status": "CURRENT"
+                            }
+                          ],
+                          "name": "route",
+                          "description": "The active RIB route for the specified\ndestination.\n\nIf no route exists in the RIB for the destination\naddress, no output is returned.\n\nAddress-family-specific modules MUST augment this\ncontainer with appropriate route contents.",
+                          "config": false,
+                          "class": "container",
+                          "status": "OBSOLETE"
+                        }],
+                        "name": "output",
+                        "description": "",
+                        "config": false,
+                        "class": "container",
+                        "status": "CURRENT"
+                      }
+                    ],
+                    "name": "active-route",
+                    "description": "Return the active RIB route that is used for the\ndestination address.\n\nAddress-family-specific modules MUST augment input\nparameters with a leaf named 'destination-address'.",
+                    "class": "action",
+                    "status": "OBSOLETE"
+                  },
+                  {
+                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:name/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "name",
+                    "description": "The name of the RIB.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "OBSOLETE"
+                  },
+                  {
+                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:address-family/",
+                    "type_info": {
+                      "description": "",
+                      "type": "identityref",
+                      "base": ["address-family"]
+                    },
+                    "children": [],
+                    "name": "address-family",
+                    "description": "Address family.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  },
+                  {
+                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:default-rib/",
+                    "type_info": {
+                      "default": "true",
+                      "description": "This flag has the value of 'true' if and only if the\nRIB is the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                      "type": "rt:default-rib"
+                    },
+                    "children": [],
+                    "name": "default-rib",
+                    "description": "This flag has the value of 'true' if and only if the\nRIB is the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "OBSOLETE"
+                  },
+                  {
+                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/",
                     "type_info": {},
                     "children": [{
-                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/",
+                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/",
                       "type_info": {},
                       "children": [
                         {
-                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/",
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:route-preference/",
+                          "type_info": {
+                            "description": "This type is used for route preferences.",
+                            "type": "rt:route-preference"
+                          },
+                          "children": [],
+                          "name": "route-preference",
+                          "description": "This route attribute, also known as 'administrative\ndistance', allows for selecting the preferred route\namong routes with the same destination prefix.  A\nsmaller value indicates a route that is\nmore preferred.",
+                          "config": false,
+                          "class": "leaf",
+                          "status": "OBSOLETE"
+                        },
+                        {
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/",
                           "type_info": {},
                           "children": [{
-                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/",
+                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/",
                             "type_info": {},
                             "children": [
                               {
-                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
                                 "type_info": {},
                                 "children": [{
-                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
                                   "type_info": {
                                     "description": "This type is used by data models that need to reference\ninterfaces.",
                                     "type": "if:interface-ref"
@@ -692,10 +918,10 @@
                                 "status": "CURRENT"
                               },
                               {
-                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
                                 "type_info": {},
                                 "children": [{
-                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
                                   "type_info": {
                                     "description": "",
                                     "type": "rt:enumeration"
@@ -714,16 +940,16 @@
                                 "status": "CURRENT"
                               },
                               {
-                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
+                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
                                 "type_info": {},
                                 "children": [{
-                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
+                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
                                   "type_info": {},
                                   "children": [{
-                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
+                                    "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
                                     "type_info": {},
                                     "children": [{
-                                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
+                                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
                                       "type_info": {
                                         "description": "This type is used by data models that need to reference\ninterfaces.",
                                         "type": "if:interface-ref"
@@ -767,7 +993,7 @@
                           "status": "OBSOLETE"
                         },
                         {
-                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:source-protocol/",
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:source-protocol/",
                           "type_info": {
                             "description": "",
                             "type": "identityref",
@@ -781,7 +1007,7 @@
                           "status": "CURRENT"
                         },
                         {
-                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:active/",
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:active/",
                           "type_info": {
                             "description": "",
                             "type": "empty"
@@ -794,7 +1020,7 @@
                           "status": "CURRENT"
                         },
                         {
-                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:active-route/rt:output/rt:route/rt:last-updated/",
+                          "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:last-updated/",
                           "type_info": {
                             "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
                             "type": "yang:date-and-time"
@@ -808,268 +1034,46 @@
                         }
                       ],
                       "name": "route",
-                      "description": "The active RIB route for the specified\ndestination.\n\nIf no route exists in the RIB for the destination\naddress, no output is returned.\n\nAddress-family-specific modules MUST augment this\ncontainer with appropriate route contents.",
+                      "description": "A RIB route entry.  This data node MUST be augmented\nwith information specific to routes of each address\nfamily.",
                       "config": false,
-                      "class": "container",
+                      "class": "list",
                       "status": "OBSOLETE"
                     }],
-                    "name": "output",
-                    "description": "",
+                    "name": "routes",
+                    "description": "Current contents of the RIB.",
                     "config": false,
                     "class": "container",
-                    "status": "CURRENT"
+                    "status": "OBSOLETE"
                   }
                 ],
-                "name": "active-route",
-                "description": "Return the active RIB route that is used for the\ndestination address.\n\nAddress-family-specific modules MUST augment input\nparameters with a leaf named 'destination-address'.",
-                "class": "action",
-                "status": "OBSOLETE"
-              },
-              {
-                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:name/",
-                "type_info": {
-                  "description": "",
-                  "type": "string"
-                },
-                "children": [],
-                "name": "name",
-                "description": "The name of the RIB.",
+                "name": "rib",
+                "description": "Each entry represents a RIB identified by the 'name'\nkey.  All routes in a RIB MUST belong to the same address\nfamily.\n\nAn implementation SHOULD provide one system-controlled\ndefault RIB for each supported address family.",
                 "config": false,
-                "class": "leaf",
+                "class": "list",
                 "status": "OBSOLETE"
-              },
-              {
-                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:address-family/",
-                "type_info": {
-                  "description": "",
-                  "type": "identityref",
-                  "base": ["address-family"]
-                },
-                "children": [],
-                "name": "address-family",
-                "description": "Address family.",
-                "config": false,
-                "class": "leaf",
-                "status": "CURRENT"
-              },
-              {
-                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:default-rib/",
-                "type_info": {
-                  "default": "true",
-                  "description": "This flag has the value of 'true' if and only if the\nRIB is the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
-                  "type": "rt:default-rib"
-                },
-                "children": [],
-                "name": "default-rib",
-                "description": "This flag has the value of 'true' if and only if the\nRIB is the default RIB for the given address family.\n\nBy default, control-plane protocols place their routes\nin the default RIBs.",
-                "config": false,
-                "class": "leaf",
-                "status": "OBSOLETE"
-              },
-              {
-                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/",
-                "type_info": {},
-                "children": [{
-                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/",
-                  "type_info": {},
-                  "children": [
-                    {
-                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:route-preference/",
-                      "type_info": {
-                        "description": "This type is used for route preferences.",
-                        "type": "rt:route-preference"
-                      },
-                      "children": [],
-                      "name": "route-preference",
-                      "description": "This route attribute, also known as 'administrative\ndistance', allows for selecting the preferred route\namong routes with the same destination prefix.  A\nsmaller value indicates a route that is\nmore preferred.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "OBSOLETE"
-                    },
-                    {
-                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/",
-                      "type_info": {},
-                      "children": [{
-                        "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/",
-                        "type_info": {},
-                        "children": [
-                          {
-                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:simple-next-hop/rt:outgoing-interface/",
-                              "type_info": {
-                                "description": "This type is used by data models that need to reference\ninterfaces.",
-                                "type": "if:interface-ref"
-                              },
-                              "children": [],
-                              "name": "outgoing-interface",
-                              "description": "Name of the outgoing interface.",
-                              "config": false,
-                              "class": "leaf",
-                              "status": "CURRENT"
-                            }],
-                            "name": "simple-next-hop",
-                            "description": "This case represents a simple next hop consisting of the\nnext-hop address and/or outgoing interface.\n\nModules for address families MUST augment this case with a\nleaf containing a next-hop address of that address\nfamily.",
-                            "config": false,
-                            "class": "case",
-                            "status": "CURRENT"
-                          },
-                          {
-                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:special-next-hop/rt:special-next-hop/",
-                              "type_info": {
-                                "description": "",
-                                "type": "rt:enumeration"
-                              },
-                              "children": [],
-                              "name": "special-next-hop",
-                              "description": "Options for special next hops.",
-                              "config": false,
-                              "class": "leaf",
-                              "status": "CURRENT"
-                            }],
-                            "name": "special-next-hop",
-                            "description": "",
-                            "config": false,
-                            "class": "case",
-                            "status": "CURRENT"
-                          },
-                          {
-                            "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/",
-                            "type_info": {},
-                            "children": [{
-                              "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/",
-                              "type_info": {},
-                              "children": [{
-                                "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/",
-                                "type_info": {},
-                                "children": [{
-                                  "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:next-hop/rt:next-hop-options/rt:next-hop-list/rt:next-hop-list/rt:next-hop/rt:outgoing-interface/",
-                                  "type_info": {
-                                    "description": "This type is used by data models that need to reference\ninterfaces.",
-                                    "type": "if:interface-ref"
-                                  },
-                                  "children": [],
-                                  "name": "outgoing-interface",
-                                  "description": "Name of the outgoing interface.",
-                                  "config": false,
-                                  "class": "leaf",
-                                  "status": "CURRENT"
-                                }],
-                                "name": "next-hop",
-                                "description": "An entry in a next-hop list.\n\nModules for address families MUST augment this list\nwith a leaf containing a next-hop address of that\naddress family.",
-                                "config": false,
-                                "class": "list",
-                                "status": "CURRENT"
-                              }],
-                              "name": "next-hop-list",
-                              "description": "Container for multiple next hops.",
-                              "config": false,
-                              "class": "container",
-                              "status": "CURRENT"
-                            }],
-                            "name": "next-hop-list",
-                            "description": "",
-                            "config": false,
-                            "class": "case",
-                            "status": "CURRENT"
-                          }
-                        ],
-                        "name": "next-hop-options",
-                        "description": "Options for next hops.\n\nIt is expected that further cases will be added through\naugments from other modules, e.g., for recursive\nnext hops.",
-                        "config": false,
-                        "class": "choice",
-                        "status": "CURRENT"
-                      }],
-                      "name": "next-hop",
-                      "description": "Route's next-hop attribute.",
-                      "config": false,
-                      "class": "container",
-                      "status": "OBSOLETE"
-                    },
-                    {
-                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:source-protocol/",
-                      "type_info": {
-                        "description": "",
-                        "type": "identityref",
-                        "base": ["routing-protocol"]
-                      },
-                      "children": [],
-                      "name": "source-protocol",
-                      "description": "Type of the routing protocol from which the route\noriginated.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:active/",
-                      "type_info": {
-                        "description": "",
-                        "type": "empty"
-                      },
-                      "children": [],
-                      "name": "active",
-                      "description": "The presence of this leaf indicates that the route is\npreferred among all routes in the same RIB that have the\nsame destination prefix.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    },
-                    {
-                      "path": "/rt:routing-state/rt:ribs/rt:rib/rt:routes/rt:route/rt:last-updated/",
-                      "type_info": {
-                        "description": "The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.",
-                        "type": "yang:date-and-time"
-                      },
-                      "children": [],
-                      "name": "last-updated",
-                      "description": "Timestamp of the last modification of the route.  If the\nroute was never modified, it is the time when the route was\ninserted into the RIB.",
-                      "config": false,
-                      "class": "leaf",
-                      "status": "CURRENT"
-                    }
-                  ],
-                  "name": "route",
-                  "description": "A RIB route entry.  This data node MUST be augmented\nwith information specific to routes of each address\nfamily.",
-                  "config": false,
-                  "class": "list",
-                  "status": "OBSOLETE"
-                }],
-                "name": "routes",
-                "description": "Current contents of the RIB.",
-                "config": false,
-                "class": "container",
-                "status": "OBSOLETE"
-              }
-            ],
-            "name": "rib",
-            "description": "Each entry represents a RIB identified by the 'name'\nkey.  All routes in a RIB MUST belong to the same address\nfamily.\n\nAn implementation SHOULD provide one system-controlled\ndefault RIB for each supported address family.",
-            "config": false,
-            "class": "list",
-            "status": "OBSOLETE"
-          }],
-          "name": "ribs",
-          "description": "Container for RIBs.",
+              }],
+              "name": "ribs",
+              "description": "Container for RIBs.",
+              "config": false,
+              "class": "container",
+              "status": "OBSOLETE"
+            }
+          ],
+          "name": "routing-state",
+          "description": "State data of the routing subsystem.",
           "config": false,
           "class": "container",
           "status": "OBSOLETE"
         }
       ],
-      "name": "routing-state",
-      "description": "State data of the routing subsystem.",
-      "config": false,
-      "class": "container",
-      "status": "OBSOLETE"
+      "module": {
+        "prefix": "rt",
+        "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:rtgwg@ietf.org>\n\nEditor:   Ladislav Lhotka\n          <mailto:lhotka@nic.cz>\n          Acee Lindem\n          <mailto:acee@cisco.com>\n          Yingzhen Qu\n          <mailto:yingzhen.qu@huawei.com>",
+        "name": "ietf-routing",
+        "namespace": "urn:ietf:params:xml:ns:yang:ietf-routing",
+        "description": "This YANG module defines essential components for the management\nof a routing subsystem.  The model fully conforms to the Network\nManagement Datastore Architecture (NMDA).\n\nCopyright (c) 2018 IETF Trust and the persons\nidentified as authors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\nThis version of this YANG module is part of RFC 8349; see\nthe RFC itself for full legal notices.",
+        "revision": "2018-03-13"
+      }
     }
-  ],
-  "module": {
-    "prefix": "rt",
-    "contact": "WG Web:   <https://datatracker.ietf.org/wg/netmod/>\nWG List:  <mailto:rtgwg@ietf.org>\n\nEditor:   Ladislav Lhotka\n          <mailto:lhotka@nic.cz>\n          Acee Lindem\n          <mailto:acee@cisco.com>\n          Yingzhen Qu\n          <mailto:yingzhen.qu@huawei.com>",
-    "name": "ietf-routing",
-    "namespace": "urn:ietf:params:xml:ns:yang:ietf-routing",
-    "description": "This YANG module defines essential components for the management\nof a routing subsystem.  The model fully conforms to the Network\nManagement Datastore Architecture (NMDA).\n\nCopyright (c) 2018 IETF Trust and the persons\nidentified as authors of the code.  All rights reserved.\n\nRedistribution and use in source and binary forms, with or\nwithout modification, is permitted pursuant to, and subject\nto the license terms contained in, the Simplified BSD License\nset forth in Section 4.c of the IETF Trust's Legal Provisions\nRelating to IETF Documents\n(https://trustee.ietf.org/license-info).\nThis version of this YANG module is part of RFC 8349; see\nthe RFC itself for full legal notices.",
-    "revision": "2018-03-13"
-  }
+  ]
 }

--- a/src/test/resources/out/compare/testModel.json
+++ b/src/test/resources/out/compare/testModel.json
@@ -1,134 +1,236 @@
 {
-  "children": [
+  "parsed-models": [
     {
-      "path": "/test:result-container/",
-      "type_info": {},
-      "children": [{
-        "path": "/test:result-container/test:result/",
-        "type_info": {},
-        "children": [
-          {
-            "path": "/test:result-container/test:result/test:id/",
-            "type_info": {
-              "description": "",
-              "type": "uint32"
-            },
-            "children": [],
-            "name": "id",
-            "description": "",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/test:result-container/test:result/test:sum-result/",
-            "type_info": {
-              "description": "",
-              "type": "test:suma-type"
-            },
-            "children": [],
-            "name": "sum-result",
-            "description": "",
-            "config": false,
-            "class": "leaf",
-            "status": "CURRENT"
-          }
-        ],
-        "name": "result",
-        "description": "",
-        "config": false,
-        "class": "list",
-        "status": "CURRENT"
-      }],
-      "name": "result-container",
-      "description": "Used for storing summation results",
-      "config": false,
-      "class": "container",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/test:operands-container/",
-      "type_info": {},
-      "children": [{
-        "path": "/test:operands-container/test:operands/",
-        "type_info": {},
-        "children": [
-          {
-            "path": "/test:operands-container/test:operands/test:id/",
-            "type_info": {
-              "description": "",
-              "type": "uint32"
-            },
-            "children": [],
-            "name": "id",
-            "description": "",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/test:operands-container/test:operands/test:operand-a/",
-            "type_info": {
-              "description": "",
-              "type": "uint16"
-            },
-            "children": [],
-            "name": "operand-a",
-            "description": "Operand A",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          },
-          {
-            "path": "/test:operands-container/test:operands/test:operand-b/",
-            "type_info": {
-              "description": "",
-              "type": "uint16"
-            },
-            "children": [],
-            "name": "operand-b",
-            "description": "Operand B",
-            "config": true,
-            "class": "leaf",
-            "status": "CURRENT"
-          }
-        ],
-        "name": "operands",
-        "description": "",
-        "config": true,
-        "class": "list",
-        "status": "CURRENT"
-      }],
-      "name": "operands-container",
-      "description": "Used for storing summation operands",
-      "config": true,
-      "class": "container",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/test:server/",
-      "type_info": {},
       "children": [
         {
-          "path": "/test:server/test:reset/",
+          "path": "/test:result-container/",
           "type_info": {},
-          "children": [
-            {
-              "path": "/test:server/test:reset/test:input/",
-              "type_info": {},
-              "children": [{
-                "path": "/test:server/test:reset/test:input/test:reset-at/",
+          "children": [{
+            "path": "/test:result-container/test:result/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/test:result-container/test:result/test:id/",
                 "type_info": {
                   "description": "",
                   "type": "uint32"
                 },
                 "children": [],
-                "name": "reset-at",
+                "name": "id",
+                "description": "",
+                "config": false,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/test:result-container/test:result/test:sum-result/",
+                "type_info": {
+                  "description": "",
+                  "type": "test:suma-type"
+                },
+                "children": [],
+                "name": "sum-result",
+                "description": "",
+                "config": false,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "result",
+            "description": "",
+            "config": false,
+            "class": "list",
+            "status": "CURRENT"
+          }],
+          "name": "result-container",
+          "description": "Used for storing summation results",
+          "config": false,
+          "class": "container",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/test:operands-container/",
+          "type_info": {},
+          "children": [{
+            "path": "/test:operands-container/test:operands/",
+            "type_info": {},
+            "children": [
+              {
+                "path": "/test:operands-container/test:operands/test:id/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint32"
+                },
+                "children": [],
+                "name": "id",
                 "description": "",
                 "config": true,
                 "class": "leaf",
                 "status": "CURRENT"
-              }],
+              },
+              {
+                "path": "/test:operands-container/test:operands/test:operand-a/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint16"
+                },
+                "children": [],
+                "name": "operand-a",
+                "description": "Operand A",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              },
+              {
+                "path": "/test:operands-container/test:operands/test:operand-b/",
+                "type_info": {
+                  "description": "",
+                  "type": "uint16"
+                },
+                "children": [],
+                "name": "operand-b",
+                "description": "Operand B",
+                "config": true,
+                "class": "leaf",
+                "status": "CURRENT"
+              }
+            ],
+            "name": "operands",
+            "description": "",
+            "config": true,
+            "class": "list",
+            "status": "CURRENT"
+          }],
+          "name": "operands-container",
+          "description": "Used for storing summation operands",
+          "config": true,
+          "class": "container",
+          "status": "CURRENT"
+        },
+        {
+          "path": "/test:server/",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/test:server/test:reset/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/test:server/test:reset/test:input/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/test:server/test:reset/test:input/test:reset-at/",
+                    "type_info": {
+                      "description": "",
+                      "type": "uint32"
+                    },
+                    "children": [],
+                    "name": "reset-at",
+                    "description": "",
+                    "config": true,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "input",
+                  "description": "",
+                  "config": true,
+                  "class": "container",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/test:server/test:reset/test:output/",
+                  "type_info": {},
+                  "children": [{
+                    "path": "/test:server/test:reset/test:output/test:reset-finished-at/",
+                    "type_info": {
+                      "description": "",
+                      "type": "string"
+                    },
+                    "children": [],
+                    "name": "reset-finished-at",
+                    "description": "",
+                    "config": false,
+                    "class": "leaf",
+                    "status": "CURRENT"
+                  }],
+                  "name": "output",
+                  "description": "",
+                  "config": false,
+                  "class": "container",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "reset",
+              "description": "",
+              "class": "action",
+              "status": "CURRENT"
+            },
+            {
+              "path": "/test:server/test:name/",
+              "type_info": {
+                "description": "",
+                "type": "string"
+              },
+              "children": [],
+              "name": "name",
+              "description": "",
+              "config": true,
+              "class": "leaf",
+              "status": "CURRENT"
+            }
+          ],
+          "name": "server",
+          "description": "",
+          "config": true,
+          "class": "list",
+          "status": "CURRENT"
+        }
+      ],
+      "module": {
+        "prefix": "test",
+        "contact": "",
+        "name": "test_model",
+        "namespace": "test:testspace",
+        "description": "Testing module",
+        "revision": "2020-12-03"
+      },
+      "rpcs": [
+        {
+          "path": "/test:multiplication/",
+          "type_info": {},
+          "children": [
+            {
+              "path": "/test:multiplication/test:input/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/test:multiplication/test:input/test:operand-a/",
+                  "type_info": {
+                    "default": "5",
+                    "description": "",
+                    "type": "test:operand-a"
+                  },
+                  "children": [],
+                  "name": "operand-a",
+                  "description": "",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/test:multiplication/test:input/test:operand-b/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint32"
+                  },
+                  "children": [],
+                  "name": "operand-b",
+                  "description": "",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
               "name": "input",
               "description": "",
               "config": true,
@@ -136,16 +238,16 @@
               "status": "CURRENT"
             },
             {
-              "path": "/test:server/test:reset/test:output/",
+              "path": "/test:multiplication/test:output/",
               "type_info": {},
               "children": [{
-                "path": "/test:server/test:reset/test:output/test:reset-finished-at/",
+                "path": "/test:multiplication/test:output/test:a-times-b/",
                 "type_info": {
                   "description": "",
-                  "type": "string"
+                  "type": "uint32"
                 },
                 "children": [],
-                "name": "reset-finished-at",
+                "name": "a-times-b",
                 "description": "",
                 "config": false,
                 "class": "leaf",
@@ -158,225 +260,127 @@
               "status": "CURRENT"
             }
           ],
-          "name": "reset",
+          "name": "multiplication",
           "description": "",
-          "class": "action",
+          "class": "rpc",
           "status": "CURRENT"
         },
         {
-          "path": "/test:server/test:name/",
-          "type_info": {
-            "description": "",
-            "type": "string"
-          },
-          "children": [],
-          "name": "name",
-          "description": "",
-          "config": true,
-          "class": "leaf",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "server",
-      "description": "",
-      "config": true,
-      "class": "list",
-      "status": "CURRENT"
-    }
-  ],
-  "module": {
-    "prefix": "test",
-    "contact": "",
-    "name": "test_model",
-    "namespace": "test:testspace",
-    "description": "Testing module",
-    "revision": "2020-12-03"
-  },
-  "rpcs": [
-    {
-      "path": "/test:multiplication/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/test:multiplication/test:input/",
+          "path": "/test:summation/",
           "type_info": {},
           "children": [
             {
-              "path": "/test:multiplication/test:input/test:operand-a/",
-              "type_info": {
-                "default": "5",
-                "description": "",
-                "type": "test:operand-a"
-              },
-              "children": [],
-              "name": "operand-a",
+              "path": "/test:summation/test:input/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/test:summation/test:input/test:operand-a/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint16"
+                  },
+                  "children": [],
+                  "name": "operand-a",
+                  "description": "Operand A",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/test:summation/test:input/test:operand-b/",
+                  "type_info": {
+                    "description": "",
+                    "type": "uint16"
+                  },
+                  "children": [],
+                  "name": "operand-b",
+                  "description": "Operand B",
+                  "config": true,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "input",
               "description": "",
               "config": true,
-              "class": "leaf",
+              "class": "container",
               "status": "CURRENT"
             },
             {
-              "path": "/test:multiplication/test:input/test:operand-b/",
-              "type_info": {
-                "description": "",
-                "type": "uint32"
-              },
-              "children": [],
-              "name": "operand-b",
+              "path": "/test:summation/test:output/",
+              "type_info": {},
+              "children": [
+                {
+                  "path": "/test:summation/test:output/test:summation-output/",
+                  "type_info": {
+                    "description": "",
+                    "type": "string"
+                  },
+                  "children": [],
+                  "name": "summation-output",
+                  "description": "",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                },
+                {
+                  "path": "/test:summation/test:output/test:sum/",
+                  "type_info": {
+                    "description": "",
+                    "type": "test:suma-type"
+                  },
+                  "children": [],
+                  "name": "sum",
+                  "description": "",
+                  "config": false,
+                  "class": "leaf",
+                  "status": "CURRENT"
+                }
+              ],
+              "name": "output",
               "description": "",
-              "config": true,
-              "class": "leaf",
+              "config": false,
+              "class": "container",
               "status": "CURRENT"
             }
           ],
-          "name": "input",
+          "name": "summation",
           "description": "",
-          "config": true,
-          "class": "container",
+          "class": "rpc",
+          "status": "CURRENT"
+        }
+      ],
+      "notifications": [
+        {
+          "path": "Absolute{qnames=[(test:testspace?revision=2020-12-03)testNotification]}",
+          "type_info": {},
+          "name": "testNotification",
+          "description": "Indicates that the toaster has run of out bread.",
+          "class": "notification",
           "status": "CURRENT"
         },
         {
-          "path": "/test:multiplication/test:output/",
+          "path": "Absolute{qnames=[(test:testspace?revision=2020-12-03)testNotificationWithData]}",
           "type_info": {},
           "children": [{
-            "path": "/test:multiplication/test:output/test:a-times-b/",
+            "path": "/test:testNotificationWithData/test:notificationData/",
             "type_info": {
               "description": "",
               "type": "uint32"
             },
             "children": [],
-            "name": "a-times-b",
+            "name": "notificationData",
             "description": "",
             "config": false,
             "class": "leaf",
             "status": "CURRENT"
           }],
-          "name": "output",
+          "name": "testNotificationWithData",
           "description": "",
-          "config": false,
-          "class": "container",
+          "class": "notification",
           "status": "CURRENT"
         }
-      ],
-      "name": "multiplication",
-      "description": "",
-      "class": "rpc",
-      "status": "CURRENT"
-    },
-    {
-      "path": "/test:summation/",
-      "type_info": {},
-      "children": [
-        {
-          "path": "/test:summation/test:input/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/test:summation/test:input/test:operand-a/",
-              "type_info": {
-                "description": "",
-                "type": "uint16"
-              },
-              "children": [],
-              "name": "operand-a",
-              "description": "Operand A",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/test:summation/test:input/test:operand-b/",
-              "type_info": {
-                "description": "",
-                "type": "uint16"
-              },
-              "children": [],
-              "name": "operand-b",
-              "description": "Operand B",
-              "config": true,
-              "class": "leaf",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "input",
-          "description": "",
-          "config": true,
-          "class": "container",
-          "status": "CURRENT"
-        },
-        {
-          "path": "/test:summation/test:output/",
-          "type_info": {},
-          "children": [
-            {
-              "path": "/test:summation/test:output/test:summation-output/",
-              "type_info": {
-                "description": "",
-                "type": "string"
-              },
-              "children": [],
-              "name": "summation-output",
-              "description": "",
-              "config": false,
-              "class": "leaf",
-              "status": "CURRENT"
-            },
-            {
-              "path": "/test:summation/test:output/test:sum/",
-              "type_info": {
-                "description": "",
-                "type": "test:suma-type"
-              },
-              "children": [],
-              "name": "sum",
-              "description": "",
-              "config": false,
-              "class": "leaf",
-              "status": "CURRENT"
-            }
-          ],
-          "name": "output",
-          "description": "",
-          "config": false,
-          "class": "container",
-          "status": "CURRENT"
-        }
-      ],
-      "name": "summation",
-      "description": "",
-      "class": "rpc",
-      "status": "CURRENT"
-    }
-  ],
-  "notifications": [
-    {
-      "path": "Absolute{qnames=[(test:testspace?revision=2020-12-03)testNotification]}",
-      "type_info": {},
-      "name": "testNotification",
-      "description": "Indicates that the toaster has run of out bread.",
-      "class": "notification",
-      "status": "CURRENT"
-    },
-    {
-      "path": "Absolute{qnames=[(test:testspace?revision=2020-12-03)testNotificationWithData]}",
-      "type_info": {},
-      "children": [{
-        "path": "/test:testNotificationWithData/test:notificationData/",
-        "type_info": {
-          "description": "",
-          "type": "uint32"
-        },
-        "children": [],
-        "name": "notificationData",
-        "description": "",
-        "config": false,
-        "class": "leaf",
-        "status": "CURRENT"
-      }],
-      "name": "testNotificationWithData",
-      "description": "",
-      "class": "notification",
-      "status": "CURRENT"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The issue with Format JsonTree is that it creates an output file that contains multiple JSON objects, one for each tested module. The results is an invalid JSON file, as the objects are not wrapped in a single outer object. The desired output for each tested module is to be wrapped in an array that is itself contained within a single outer object.

Before:
```
{
  yang_model_1
}
{
  yang_model_2
}
```

After:
```
{
  "parsed_models": [
    {
      yang_model_1
    },
    {
      yang_model_2
    },
    ...
  ]
}
```

Assertion test failures expected, since output of JsonTree has changed.
