### PR TITLE
Fix leafref output to use correct path expressions

### DIFF
--- a/src/main/java/io/lighty/yang/validator/formats/Line.java
+++ b/src/main/java/io/lighty/yang/validator/formats/Line.java
@@ -141,7 +141,7 @@ abstract class Line {
             }
         }
         if (type instanceof LeafrefTypeDefinition) {
-            path = ((LeafrefTypeDefinition) type).getPathStatement().toString();
+            path = ((LeafrefTypeDefinition) type).getPathStatement().getOriginalString();
         } else {
             path = null;
         }

--- a/src/test/resources/integration/compare/integrationTestTreeRecursive.txt
+++ b/src/test/resources/integration/compare/integrationTestTreeRecursive.txt
@@ -21,8 +21,8 @@ module: ietf-interfaces-modified
   |     +--ro last-change?       yang:date-and-time
   |     +--ro if-index       int32 {if-mib}?
   |     +--ro phys-address?       string
-  |     +--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)name}]}}, originalString=/ifm:interfaces/ifm:interface/ifm:name}
-  |     +--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)name}]}}, originalString=/ifm:interfaces/ifm:interface/ifm:name}
+  |     +--ro higher-layer-if*    -> /ifm:interfaces/ifm:interface/ifm:name
+  |     +--ro lower-layer-if*    -> /ifm:interfaces/ifm:interface/ifm:name
   |     +--ro speed?       yang:gauge64
   |     +--ro statistics
   |        +--ro discontinuity-time       yang:date-and-time
@@ -48,8 +48,8 @@ module: ietf-interfaces-modified
         x--ro last-change?       yang:date-and-time
         x--ro if-index       int32 {if-mib}?
         x--ro phys-address?       string
-        x--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)name}]}}, originalString=/ifm:interfaces-state/ifm:interface/ifm:name}
-        x--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces-modified?revision=2018-02-20)name}]}}, originalString=/ifm:interfaces-state/ifm:interface/ifm:name}
+        x--ro higher-layer-if*    -> /ifm:interfaces-state/ifm:interface/ifm:name
+        x--ro lower-layer-if*    -> /ifm:interfaces-state/ifm:interface/ifm:name
         x--ro speed?       yang:gauge64
         x--ro statistics
            x--ro discontinuity-time       yang:date-and-time

--- a/src/test/resources/out/compare/connectionOrientedOam.tree
+++ b/src/test/resources/out/compare/connectionOrientedOam.tree
@@ -49,7 +49,7 @@ module: ietf-connection-oriented-oam
               |     +--rw cos-id?       uint8
               +--rw mip* [name] {mip}?
                  +--rw name       string
-                 +--rw interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+                 +--rw interface?    -> /if:interfaces/if:interface/if:name
                  +--rw (mip-address)?
                     +-- :(mac-address)
                     |  +--rw mac-address?       string
@@ -59,13 +59,13 @@ RPCs:
   +---x continuity-check {continuity-check}?
   |  +---w input
   |  |  +---w technology?       identityref
-  |  |  +---w md-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-name-string}}]}}, originalString=/domains/domain/md-name-string}
-  |  |  +---w md-level?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-level}}]}}, originalString=/domains/domain/md-level}
-  |  |  +---w ma-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=ma-name-string}}]}}, originalString=/domains/domain/mas/ma/ma-name-string}
+  |  |  +---w md-name-string    -> /domains/domain/md-name-string
+  |  |  +---w md-level?    -> /domains/domain/md-level
+  |  |  +---w ma-name-string    -> /domains/domain/mas/ma/ma-name-string
   |  |  +---w cos-id?       uint8
   |  |  +---w ttl?       uint8
   |  |  +---w sub-type?       identityref
-  |  |  +---w source-mep?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=mep}}, Step{axis=child, qname=Unqualified{localName=mep-name}}]}}, originalString=/domains/domain/mas/ma/mep/mep-name}
+  |  |  +---w source-mep?    -> /domains/domain/mas/ma/mep/mep-name
   |  |  +---w destination-mep
   |  |  |  +---w (mep-address)?
   |  |  |  |  +-- :(mac-address)
@@ -85,13 +85,13 @@ RPCs:
   |           +--ro monitor-null?       empty
   +---x continuity-verification {connectivity-verification}?
   |  +---w input
-  |  |  +---w md-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-name-string}}]}}, originalString=/domains/domain/md-name-string}
-  |  |  +---w md-level?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-level}}]}}, originalString=/domains/domain/md-level}
-  |  |  +---w ma-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=ma-name-string}}]}}, originalString=/domains/domain/mas/ma/ma-name-string}
+  |  |  +---w md-name-string    -> /domains/domain/md-name-string
+  |  |  +---w md-level?    -> /domains/domain/md-level
+  |  |  +---w ma-name-string    -> /domains/domain/mas/ma/ma-name-string
   |  |  +---w cos-id?       uint8
   |  |  +---w ttl?       uint8
   |  |  +---w sub-type?       identityref
-  |  |  +---w source-mep?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=mep}}, Step{axis=child, qname=Unqualified{localName=mep-name}}]}}, originalString=/domains/domain/mas/ma/mep/mep-name}
+  |  |  +---w source-mep?    -> /domains/domain/mas/ma/mep/mep-name
   |  |  +---w destination-mep
   |  |  |  +---w (mep-address)?
   |  |  |  |  +-- :(mac-address)
@@ -111,13 +111,13 @@ RPCs:
   |           +--ro monitor-null?       empty
   +---x traceroute {traceroute}?
      +---w input
-     |  +---w md-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-name-string}}]}}, originalString=/domains/domain/md-name-string}
-     |  +---w md-level?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-level}}]}}, originalString=/domains/domain/md-level}
-     |  +---w ma-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=ma-name-string}}]}}, originalString=/domains/domain/mas/ma/ma-name-string}
+     |  +---w md-name-string    -> /domains/domain/md-name-string
+     |  +---w md-level?    -> /domains/domain/md-level
+     |  +---w ma-name-string    -> /domains/domain/mas/ma/ma-name-string
      |  +---w cos-id?       uint8
      |  +---w ttl?       uint8
      |  +---w command-sub-type?       identityref
-     |  +---w source-mep?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=mep}}, Step{axis=child, qname=Unqualified{localName=mep-name}}]}}, originalString=/domains/domain/mas/ma/mep/mep-name}
+     |  +---w source-mep?    -> /domains/domain/mas/ma/mep/mep-name
      |  +---w destination-mep
      |  |  +---w (mep-address)?
      |  |  |  +-- :(mac-address)
@@ -145,7 +145,7 @@ RPCs:
            |  |     +--ro mep-id-int?       int32
            |  +--ro mep-id-format?       identityref
            +--ro mip {mip}?
-           |  +--ro interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+           |  +--ro interface?    -> /if:interfaces/if:interface/if:name
            |  +--ro (mip-address)?
            |     +-- :(mac-address)
            |     |  +--ro mac-address?       string
@@ -157,9 +157,9 @@ RPCs:
 notifications:
   +---n defect-condition-notification
      +--ro technology?       identityref
-     +--ro md-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-name-string}}]}}, originalString=/domains/domain/md-name-string}
-     +--ro ma-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=ma-name-string}}]}}, originalString=/domains/domain/mas/ma/ma-name-string}
-     +--ro mep-name?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=mep}}, Step{axis=child, qname=Unqualified{localName=mep-name}}]}}, originalString=/domains/domain/mas/ma/mep/mep-name}
+     +--ro md-name-string    -> /domains/domain/md-name-string
+     +--ro ma-name-string    -> /domains/domain/mas/ma/ma-name-string
+     +--ro mep-name?    -> /domains/domain/mas/ma/mep/mep-name
      +--ro defect-type?       identityref
      +--ro generating-mepid
      |  +--ro (mep-id)?
@@ -173,9 +173,9 @@ notifications:
            +--ro defect-code?       int32
   +---n defect-cleared-notification
      +--ro technology?       identityref
-     +--ro md-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=md-name-string}}]}}, originalString=/domains/domain/md-name-string}
-     +--ro ma-name-string    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=ma-name-string}}]}}, originalString=/domains/domain/mas/ma/ma-name-string}
-     +--ro mep-name?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=Unqualified{localName=domains}}, Step{axis=child, qname=Unqualified{localName=domain}}, Step{axis=child, qname=Unqualified{localName=mas}}, Step{axis=child, qname=Unqualified{localName=ma}}, Step{axis=child, qname=Unqualified{localName=mep}}, Step{axis=child, qname=Unqualified{localName=mep-name}}]}}, originalString=/domains/domain/mas/ma/mep/mep-name}
+     +--ro md-name-string    -> /domains/domain/md-name-string
+     +--ro ma-name-string    -> /domains/domain/mas/ma/ma-name-string
+     +--ro mep-name?    -> /domains/domain/mas/ma/mep/mep-name
      +--ro defect-type?       identityref
      +--ro generating-mepid
      |  +--ro (mep-id)?

--- a/src/test/resources/out/compare/interfaces-limited-depth.tree
+++ b/src/test/resources/out/compare/interfaces-limited-depth.tree
@@ -11,8 +11,8 @@ module: ietf-interfaces
   |     +--ro last-change?       yang:date-and-time
   |     +--ro if-index       int32 {if-mib}?
   |     +--ro phys-address?       string
-  |     +--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
-  |     +--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |     +--ro higher-layer-if*    -> /if:interfaces/if:interface/if:name
+  |     +--ro lower-layer-if*    -> /if:interfaces/if:interface/if:name
   |     +--ro speed?       yang:gauge64
   |     +--ro statistics
   x--ro interfaces-state
@@ -24,7 +24,7 @@ module: ietf-interfaces
         x--ro last-change?       yang:date-and-time
         x--ro if-index       int32 {if-mib}?
         x--ro phys-address?       string
-        x--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
-        x--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
+        x--ro higher-layer-if*    -> /if:interfaces-state/if:interface/if:name
+        x--ro lower-layer-if*    -> /if:interfaces-state/if:interface/if:name
         x--ro speed?       yang:gauge64
         x--ro statistics

--- a/src/test/resources/out/compare/interfaces-prefix-module.tree
+++ b/src/test/resources/out/compare/interfaces-prefix-module.tree
@@ -11,8 +11,8 @@ module: ietf-interfaces
   |     +--ro last-change?       ietf-yang-types:date-and-time
   |     +--ro if-index       int32 {if-mib}?
   |     +--ro phys-address?       string
-  |     +--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
-  |     +--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |     +--ro higher-layer-if*    -> /if:interfaces/if:interface/if:name
+  |     +--ro lower-layer-if*    -> /if:interfaces/if:interface/if:name
   |     +--ro speed?       ietf-yang-types:gauge64
   |     +--ro statistics
   |        +--ro discontinuity-time       ietf-yang-types:date-and-time
@@ -38,8 +38,8 @@ module: ietf-interfaces
         x--ro last-change?       ietf-yang-types:date-and-time
         x--ro if-index       int32 {if-mib}?
         x--ro phys-address?       string
-        x--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
-        x--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
+        x--ro higher-layer-if*    -> /if:interfaces-state/if:interface/if:name
+        x--ro lower-layer-if*    -> /if:interfaces-state/if:interface/if:name
         x--ro speed?       ietf-yang-types:gauge64
         x--ro statistics
            x--ro discontinuity-time       ietf-yang-types:date-and-time

--- a/src/test/resources/out/compare/interfaces.tree
+++ b/src/test/resources/out/compare/interfaces.tree
@@ -11,8 +11,8 @@ module: ietf-interfaces
   |     +--ro last-change?       yang:date-and-time
   |     +--ro if-index       int32 {if-mib}?
   |     +--ro phys-address?       string
-  |     +--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
-  |     +--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |     +--ro higher-layer-if*    -> /if:interfaces/if:interface/if:name
+  |     +--ro lower-layer-if*    -> /if:interfaces/if:interface/if:name
   |     +--ro speed?       yang:gauge64
   |     +--ro statistics
   |        +--ro discontinuity-time       yang:date-and-time
@@ -38,8 +38,8 @@ module: ietf-interfaces
         x--ro last-change?       yang:date-and-time
         x--ro if-index       int32 {if-mib}?
         x--ro phys-address?       string
-        x--ro higher-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
-        x--ro lower-layer-if*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
+        x--ro higher-layer-if*    -> /if:interfaces-state/if:interface/if:name
+        x--ro lower-layer-if*    -> /if:interfaces-state/if:interface/if:name
         x--ro speed?       yang:gauge64
         x--ro statistics
            x--ro discontinuity-time       yang:date-and-time

--- a/src/test/resources/out/compare/routing.tree
+++ b/src/test/resources/out/compare/routing.tree
@@ -2,7 +2,7 @@ module: ietf-routing
   +--rw routing
   |  +--rw router-id?       yang:dotted-quad
   |  +--ro interfaces
-  |  |  +--ro interface*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |  |  +--ro interface*    -> /if:interfaces/if:interface/if:name
   |  +--rw control-plane-protocols
   |  |  +--rw control-plane-protocol* [type, name]
   |  |     +--rw type       identityref
@@ -20,13 +20,13 @@ module: ietf-routing
   |        |     +--ro next-hop
   |        |     |  +--ro (next-hop-options)
   |        |     |     +-- :(simple-next-hop)
-  |        |     |     |  +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |        |     |     |  +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
   |        |     |     +-- :(special-next-hop)
   |        |     |     |  +--ro special-next-hop?       enumeration
   |        |     |     +-- :(next-hop-list)
   |        |     |        +--ro next-hop-list
   |        |     |           +--ro next-hop*
-  |        |     |              +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |        |     |              +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
   |        |     +--ro source-protocol       identityref
   |        |     +--ro active?       empty
   |        |     +--ro last-updated?       yang:date-and-time
@@ -37,20 +37,20 @@ module: ietf-routing
   |                 +--ro next-hop
   |                 |  +--ro (next-hop-options)
   |                 |     +-- :(simple-next-hop)
-  |                 |     |  +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |                 |     |  +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
   |                 |     +-- :(special-next-hop)
   |                 |     |  +--ro special-next-hop?       enumeration
   |                 |     +-- :(next-hop-list)
   |                 |        +--ro next-hop-list
   |                 |           +--ro next-hop*
-  |                 |              +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+  |                 |              +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
   |                 +--ro source-protocol       identityref
   |                 +--ro active?       empty
   |                 +--ro last-updated?       yang:date-and-time
   o--ro routing-state
      +--ro router-id?       yang:dotted-quad
      o--ro interfaces
-     |  o--ro interface*    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces-state}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces-state/if:interface/if:name}
+     |  o--ro interface*    -> /if:interfaces-state/if:interface/if:name
      o--ro control-plane-protocols
      |  o--ro control-plane-protocol* [type, name]
      |     o--ro type       identityref
@@ -66,13 +66,13 @@ module: ietf-routing
            |     o--ro next-hop
            |     |  +--ro (next-hop-options)
            |     |     +-- :(simple-next-hop)
-           |     |     |  +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+           |     |     |  +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
            |     |     +-- :(special-next-hop)
            |     |     |  +--ro special-next-hop?       enumeration
            |     |     +-- :(next-hop-list)
            |     |        +--ro next-hop-list
            |     |           +--ro next-hop*
-           |     |              +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+           |     |              +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
            |     +--ro source-protocol       identityref
            |     +--ro active?       empty
            |     +--ro last-updated?       yang:date-and-time
@@ -82,13 +82,13 @@ module: ietf-routing
                     o--ro next-hop
                     |  +--ro (next-hop-options)
                     |     +-- :(simple-next-hop)
-                    |     |  +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+                    |     |  +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
                     |     +-- :(special-next-hop)
                     |     |  +--ro special-next-hop?       enumeration
                     |     +-- :(next-hop-list)
                     |        +--ro next-hop-list
                     |           +--ro next-hop*
-                    |              +--ro outgoing-interface?    -> ParsedPathExpression{steps=LocationPathSteps{locationPath=YangLocationPath{absolute=true, steps=[Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interfaces}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)interface}, Step{axis=child, qname=(urn:ietf:params:xml:ns:yang:ietf-interfaces?revision=2018-02-20)name}]}}, originalString=/if:interfaces/if:interface/if:name}
+                    |              +--ro outgoing-interface?    -> /if:interfaces/if:interface/if:name
                     +--ro source-protocol       identityref
                     +--ro active?       empty
                     +--ro last-updated?       yang:date-and-time


### PR DESCRIPTION
Refactor code to use original string representation of path statement instead of string representation in tree output format.

JIRA:LIGHTY-148
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 841f85dd5b547ffa8f5b3926fe00dd9f5d106b90)