### PR TITLE
Bump lighty.io core to 16.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.lighty.core</groupId>
         <artifactId>lighty-parent</artifactId>
-        <version>16.3.0</version>
+        <version>16.4.0</version>
     </parent>
 
     <groupId>io.lighty.yang.validator</groupId>


### PR DESCRIPTION
Bump lighty.io core to 16.4.0 to maintain compatibility with OpenDaylight Sulfur SR4 and get useful fixes.

JIRA:LIGHTY-216