### PR TITLE
Switch all scripts to use Temurin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: 17
-        distribution: 'zulu'
+        distribution: 'temurin'
     - name: Cache SonarCloud packages
       uses: actions/cache@v1
       if: ${{ env.SONAR_TOKEN != 0 }}


### PR DESCRIPTION
Use Eclipse Temurin JDK in all lighty.io yang validator scripts used by Github Actions.

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 2614b294aa74a19d0bc208de4eeff5b3d173cdd3)