### PR TITLE
Bump org.json:json to 20231013

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20230227</version>
+            <version>20231013</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-ORGJSON-5962464

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 18577d7547da5b3e3c3de071792a5e0eed7ce396)