### PR TITLE
Bump ch.qos.logback dependencies to 1.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.11</version>
+            <version>1.4.12</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.11</version>
+            <version>1.4.12</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-6094942
- https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-6094943

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit ff96505630fe38e9bcde0a40dec7bc135e2069e9)