### PR TITLE
Bump ch.qos.logback to 1.4.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.4.12</version>
+            <version>1.4.14</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.12</version>
+            <version>1.4.14</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-6097492
- https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-6097493

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 6659ebf8ac5c995fac626b950c561b967fd7c5db)