### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,14 +30,14 @@ jobs:
       with:
         maven-version: 3.9.8
     - name: Cache SonarCloud packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       if: ${{ env.SONAR_TOKEN != 0 }}
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache Maven packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Update these deprecated actions to latest v4 version: https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/ https://github.com/actions/cache/blob/main/examples.md#java---maven

JIRA: LIGHTY-344
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 6e7d6371d5e4f807471cc89c41ffc8391480f23a)