### PR TITLE
[19.x] Fix #315 logger framework incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20240303</version>


### PR DESCRIPTION
Two different logging framework were mixed: Logback and Log4j2, which both implement the org.slf4j.API but are incompatible in this scenario. Resolve this issue using this solution:
https://stackoverflow.com/questions/45133523/classcaseexception-org-slf4j-impl-simpleloggerfactory-cannot-be-cast-to-ch-qos-l/45136892#45136892

JIRA: LIGHTY-350
Signed-off-by: tobias.pobocik <tobias.pobocik@pantheon.tech>
(cherry picked from commit 6b225af2732fa594c1a9a1c9c7cefd513346d0a1)