### PR TITLE
Exclude lighty.io core logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <parent>
         <groupId>io.lighty.core</groupId>
-        <artifactId>lighty-parent</artifactId>
+        <artifactId>lighty-minimal-parent</artifactId>
         <version>21.1.0</version>
         <relativePath/>
     </parent>
@@ -25,6 +25,8 @@
     <packaging>jar</packaging>
 
     <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+
         <application.main.class>io.lighty.yang.validator.Main</application.main.class>
         <application.attach.zip>true</application.attach.zip>
         <logback-version>1.5.12</logback-version>
@@ -124,6 +126,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
                 <executions>
                     <!-- Copy files from "src/main/assembly/resources" and move it to build target directory -->
                     <execution>


### PR DESCRIPTION
lighty-parent is adding logging dependencies like log4j which is conflicting with lighty.io validator logic depending on logback (and hard-casting to it).

Use lighty-minimal-parent instead which just declares needed lighty.io core and OpenDaylight dependencies.

JIRA: LIGHTY-350
Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>
(cherry picked from commit 1f29bb889bb5badf27c05cd82f1304c6878ff547)