### PR TITLE
Rework tests to use junit.jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/io/lighty/yang/validator/FormatTest.java
+++ b/src/test/java/io/lighty/yang/validator/FormatTest.java
@@ -17,11 +17,13 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.nio.file.Paths;
 import java.util.List;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class FormatTest implements Cleanable {
 
     protected String yangPath;
@@ -32,7 +34,7 @@ public abstract class FormatTest implements Cleanable {
     private Method method;
     private Constructor<Main> constructor;
 
-    @BeforeClass
+    @BeforeAll
     public void init() {
         outPath = TreeTest.class.getResource("/out").getFile();
         yangPath = MainTest.class.getResource("/yang").getFile();
@@ -42,7 +44,7 @@ public abstract class FormatTest implements Cleanable {
                 .setOutput(this.outPath);
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUpOutput() throws Exception {
         this.constructor = (Constructor<Main>) Main.class.getDeclaredConstructors()[0];
         this.constructor.setAccessible(true);
@@ -53,7 +55,7 @@ public abstract class FormatTest implements Cleanable {
         this.method.invoke(mainClass, this.builder.build());
     }
 
-    @AfterMethod
+    @AfterEach
     public void removeOuptut() throws Exception {
         tearDown();
         this.method.setAccessible(false);

--- a/src/test/java/io/lighty/yang/validator/IntegrationTest.java
+++ b/src/test/java/io/lighty/yang/validator/IntegrationTest.java
@@ -7,19 +7,22 @@
  */
 package io.lighty.yang.validator;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.lighty.yang.validator.formats.FormatPlugin;
 import io.lighty.yang.validator.utils.ItUtils;
 import java.io.IOException;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class IntegrationTest implements Cleanable {
 
-    @AfterClass
+    @AfterAll
     public void cleanOutput() throws IOException {
         tearDown();
     }
@@ -44,7 +47,10 @@ public class IntegrationTest implements Cleanable {
     @Test
     public void noFormatValidationTest() throws Exception {
         final var outPath = ItUtils.class.getResource(ItUtils.OUTPUT_FOLDER).getFile();
-        final var args = new String[]{"-o", outPath, "yang/deviation/model.yang"};
+        final var modelResource = ItUtils.class.getClassLoader().getResource(
+            "yang/deviation/model@2022-11-30.yang");
+        assertNotNull(modelResource);
+        final var args = new String[]{"-o", outPath, modelResource.getFile()};
         final var lyvOutput = ItUtils.startLyvWithFileOutput(args);
         assertFalse(lyvOutput.trim().isEmpty());
         final var outputWithoutGenInfo = ItUtils.removeHtmlGeneratedInfo(lyvOutput);
@@ -70,7 +76,7 @@ public class IntegrationTest implements Cleanable {
     public void treeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/test_model@2020-12-03.yang", "tree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestTree.txt");
-        assertEquals(lyvOutput, expectedOutput);
+        assertEquals(expectedOutput, lyvOutput);
     }
 
     @Test
@@ -78,7 +84,7 @@ public class IntegrationTest implements Cleanable {
         final String lyvOutput = ItUtils.startRecursivelyLyvWithFileOutput("yang",
                 "integration/yang/ietf-interfaces-modified@2018-02-20.yang", "tree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestTreeRecursive.txt");
-        assertEquals(lyvOutput, expectedOutput);
+        assertEquals(expectedOutput, lyvOutput);
     }
 
     @Test
@@ -110,7 +116,7 @@ public class IntegrationTest implements Cleanable {
     public void jsonTreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/test_model@2020-12-03.yang", "json-tree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestJsonTree.json");
-        assertEquals(lyvOutput, expectedOutput);
+        assertEquals(expectedOutput, lyvOutput);
     }
 
     @Test
@@ -125,7 +131,7 @@ public class IntegrationTest implements Cleanable {
     public void jstreeFormatTest() throws IOException {
         final String lyvOutput = ItUtils.startLyvWithFileOutput("yang/test_model@2020-12-03.yang", "jstree");
         final String expectedOutput = ItUtils.getExpectedOutput("integrationTestJsTree.html");
-        assertEquals(lyvOutput.replaceAll(" \n", "\n"), expectedOutput);
+        assertEquals(expectedOutput, lyvOutput.replaceAll(" \n", "\n"));
     }
 
     @Test

--- a/src/test/java/io/lighty/yang/validator/MainTest.java
+++ b/src/test/java/io/lighty/yang/validator/MainTest.java
@@ -26,6 +26,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.xml.stream.XMLInputFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.opendaylight.yangtools.yang.data.api.schema.ContainerNode;
 import org.opendaylight.yangtools.yang.data.api.schema.DataContainerChild;
 import org.opendaylight.yangtools.yang.data.api.schema.stream.NormalizedNodeStreamWriter;
@@ -34,15 +38,13 @@ import org.opendaylight.yangtools.yang.data.impl.schema.ImmutableNormalizedNodeS
 import org.opendaylight.yangtools.yang.data.impl.schema.NormalizationResultHolder;
 import org.opendaylight.yangtools.yang.model.api.EffectiveModelContext;
 import org.opendaylight.yangtools.yang.model.api.Module;
-import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.Test;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class MainTest implements Cleanable {
 
     private static final XMLInputFactory FACTORY = XMLInputFactory.newInstance();
 
-    @AfterTest
+    @AfterAll
     public void removeOuptut() throws Exception {
         tearDown();
     }
@@ -85,9 +87,9 @@ public class MainTest implements Cleanable {
                     xmlParser.parse(reader);
                 }
                 final var node = result.getResult().data();
-                Assert.assertTrue(node instanceof ContainerNode);
+                Assertions.assertTrue(node instanceof ContainerNode);
                 final Collection<DataContainerChild> value = ((ContainerNode) node).body();
-                Assert.assertEquals(value.size(), 1);
+                Assertions.assertEquals(1, value.size());
             }
         }
     }

--- a/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
+++ b/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
@@ -8,7 +8,7 @@
 package io.lighty.yang.validator;
 
 import static io.lighty.yang.validator.Main.startLyv;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.lighty.yang.validator.config.Configuration;
 import io.lighty.yang.validator.config.ConfigurationBuilder;
@@ -24,11 +24,13 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TreeSimplifiedTest implements Cleanable {
 
     private String yangPath;
@@ -39,13 +41,13 @@ public class TreeSimplifiedTest implements Cleanable {
     private Method method;
     private Constructor<Main> constructor;
 
-    @BeforeClass
+    @BeforeAll
     public void init() {
         outPath = TreeSimplifiedTest.class.getResource("/out").getFile();
         yangPath = TreeSimplifiedTest.class.getResource("/yang").getFile();
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUpOutput() throws Exception {
         constructor = (Constructor<Main>) Main.class.getDeclaredConstructors()[0];
         constructor.setAccessible(true);
@@ -59,7 +61,7 @@ public class TreeSimplifiedTest implements Cleanable {
         method.invoke(mainClass, builder.build());
     }
 
-    @AfterMethod
+    @AfterEach
     public void removeOuptut() throws Exception {
         tearDown();
         method.setAccessible(false);

--- a/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
+++ b/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
@@ -8,7 +8,7 @@
 package io.lighty.yang.validator.check.update.from;
 
 import static io.lighty.yang.validator.Main.checkUpdateForm;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.lighty.yang.validator.Cleanable;
 import io.lighty.yang.validator.Main;
@@ -21,11 +21,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RFC6020Test implements Cleanable {
 
     private static final String NEW = "/checkUpdateFromYangWithProblems/new/";
@@ -40,13 +42,13 @@ public class RFC6020Test implements Cleanable {
     private Method method;
     private Constructor<Main> constructor;
 
-    @BeforeClass
+    @BeforeAll
     public void init() {
         outPath = RFC6020Test.class.getResource("/out").getFile();
         yangPath = RFC6020Test.class.getResource("/yang").getFile();
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUpOutput() throws Exception {
         constructor = (Constructor<Main>) Main.class.getDeclaredConstructors()[0];
         constructor.setAccessible(true);
@@ -63,7 +65,7 @@ public class RFC6020Test implements Cleanable {
         method.invoke(mainClass, builder.build());
     }
 
-    @AfterMethod
+    @AfterEach
     public void removeOuptut() throws Exception {
         tearDown();
         method.setAccessible(false);

--- a/src/test/java/io/lighty/yang/validator/formats/AnalyzerTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/AnalyzerTest.java
@@ -21,12 +21,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class AnalyzerTest implements Cleanable {
 
     private String yangPath;
@@ -36,7 +38,7 @@ public class AnalyzerTest implements Cleanable {
     private Method method;
     private Constructor<Main> constructor;
 
-    @BeforeClass
+    @BeforeAll
     public void init() {
         outPath = TreeTest.class.getResource("/out").getFile();
         yangPath = MainTest.class.getResource("/yang").getFile();
@@ -46,7 +48,7 @@ public class AnalyzerTest implements Cleanable {
                 .setOutput(outPath);
     }
 
-    @BeforeMethod
+    @BeforeEach
     public void setUpOutput() throws Exception {
         constructor = (Constructor<Main>) Main.class.getDeclaredConstructors()[0];
         constructor.setAccessible(true);
@@ -62,7 +64,7 @@ public class AnalyzerTest implements Cleanable {
         builder.setTreeConfiguration(0, 0, false, false, false);
     }
 
-    @AfterMethod
+    @AfterEach
     public void removeOuptut() throws Exception {
         tearDown();
         method.setAccessible(false);
@@ -84,7 +86,7 @@ public class AnalyzerTest implements Cleanable {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        Assert.assertEquals(fileCreated, compareWith);
+        Assertions.assertEquals(compareWith, fileCreated);
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/DependsTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/DependsTest.java
@@ -8,7 +8,7 @@
 package io.lighty.yang.validator.formats;
 
 import static io.lighty.yang.validator.Main.startLyv;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.lighty.yang.validator.FormatTest;
 import java.nio.file.Files;
@@ -18,7 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class DependsTest extends FormatTest {
 

--- a/src/test/java/io/lighty/yang/validator/formats/JsTreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/JsTreeTest.java
@@ -8,7 +8,7 @@
 package io.lighty.yang.validator.formats;
 
 import static io.lighty.yang.validator.Main.startLyv;
-import static org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.lighty.yang.validator.FormatTest;
 import java.nio.file.Files;
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsTreeTest extends FormatTest {
 

--- a/src/test/java/io/lighty/yang/validator/formats/JsonTreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/JsonTreeTest.java
@@ -7,13 +7,14 @@
  */
 package io.lighty.yang.validator.formats;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.lighty.yang.validator.FormatTest;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.Assert;
 
 public class JsonTreeTest extends FormatTest {
 
@@ -64,7 +65,7 @@ public class JsonTreeTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        Assert.assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        assertEquals(compareWith.replaceAll("\\s+", ""), fileCreated.replaceAll("\\s+", ""));
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/NameRevisionTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/NameRevisionTest.java
@@ -7,13 +7,14 @@
  */
 package io.lighty.yang.validator.formats;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.lighty.yang.validator.FormatTest;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.Assert;
 
 public class NameRevisionTest extends FormatTest {
 
@@ -64,7 +65,7 @@ public class NameRevisionTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        Assert.assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        assertEquals(compareWith.replaceAll("\\s+", ""), fileCreated.replaceAll("\\s+", ""));
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/TreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/TreeTest.java
@@ -15,8 +15,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TreeTest extends FormatTest {
 
@@ -121,7 +121,7 @@ public class TreeTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        Assert.assertEquals(fileCreated, compareWith);
+        Assertions.assertEquals(compareWith, fileCreated);
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
+++ b/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
@@ -7,9 +7,9 @@
  */
 package io.lighty.yang.validator.utils;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.lighty.yang.validator.Main;
 import java.io.IOException;


### PR DESCRIPTION
Replace all testng with junit.jupiter throughout the entire lighty.io project.

JIRA: LIGHTY-409