### PR TITLE
Reorder incorrect assertion

### DIFF
--- a/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
+++ b/src/test/java/io/lighty/yang/validator/TreeSimplifiedTest.java
@@ -79,7 +79,7 @@ public class TreeSimplifiedTest implements Cleanable {
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(
             outLog.resolveSibling("compare").resolve("interfacesSimplified.tree"));
-        assertEquals(fileCreated, compareWith);
+        assertEquals(compareWith, fileCreated);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class TreeSimplifiedTest implements Cleanable {
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(
             outLog.resolveSibling("compare").resolve("interfaces-simplified.yang"));
-        assertEquals(fileCreated, compareWith);
+        assertEquals(compareWith, fileCreated);
     }
 
     private void prepare(final String format, final FormatPlugin plugin) {

--- a/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
+++ b/src/test/java/io/lighty/yang/validator/check/update/from/RFC6020Test.java
@@ -112,7 +112,7 @@ public class RFC6020Test implements Cleanable {
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling(COMPARE).resolve(comapreFile));
 
-        assertEquals(fileCreated, compareWith);
+        assertEquals(compareWith, fileCreated);
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/DependsTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/DependsTest.java
@@ -143,7 +143,7 @@ public class DependsTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        assertEquals(compareWith.replaceAll("\\s+", ""), fileCreated.replaceAll("\\s+", ""));
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/formats/JsTreeTest.java
+++ b/src/test/java/io/lighty/yang/validator/formats/JsTreeTest.java
@@ -78,7 +78,7 @@ public class JsTreeTest extends FormatTest {
         final Path outLog = Paths.get(outPath).resolve("out.log");
         final String fileCreated = Files.readString(outLog);
         final String compareWith = Files.readString(outLog.resolveSibling("compare").resolve(comapreWithFileName));
-        assertEquals(fileCreated.replaceAll("\\s+", ""), compareWith.replaceAll("\\s+", ""));
+        assertEquals(compareWith.replaceAll("\\s+", ""), fileCreated.replaceAll("\\s+", ""));
     }
 
 }

--- a/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
+++ b/src/test/java/io/lighty/yang/validator/utils/ItUtils.java
@@ -140,7 +140,7 @@ public final class ItUtils {
         verifyLengthOfElements(splitOut, splitExp);
         splitExp.sort(null);
         splitOut.sort(null);
-        assertEquals(splitOut, splitExp);
+        assertEquals(splitExp, splitOut);
     }
 
     private static void verifyLengthOfElements(final List<String> output, final List<String> expected) {


### PR DESCRIPTION
Some test classes have not had their expected/actual values reordered after moving to junit.

JIRA: LIGHTY-409